### PR TITLE
feat(admin): add supervisee management with edit profile aligned to signup

### DIFF
--- a/src/app/admin/supervisees/details/[id]/page.tsx
+++ b/src/app/admin/supervisees/details/[id]/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ViewDetails from "@/components/page/Supervisee/ViewDetails/index";
+
+interface SuperviseeDetailsProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function SuperviseeDetailsPage({ params }: SuperviseeDetailsProps) {
+  const { id } = await params;
+
+  return <ViewDetails id={id} />;
+}

--- a/src/app/admin/supervisees/page.tsx
+++ b/src/app/admin/supervisees/page.tsx
@@ -1,0 +1,17 @@
+import React, { Suspense } from "react";
+import Supervisees from "@/components/page/Supervisee";
+import FullScreenSpinner from "@/components/ui/FullScreenSpinner";
+
+function SuperviseesContent() {
+  return <Supervisees />;
+}
+
+const SuperviseesPage: React.FC = () => {
+  return (
+    <Suspense fallback={<FullScreenSpinner isVisible={true} message="Loading supervisees..." />}>
+      <SuperviseesContent />
+    </Suspense>
+  );
+};
+
+export default SuperviseesPage;

--- a/src/app/admin/supervision-reviews/details/[id]/page.tsx
+++ b/src/app/admin/supervision-reviews/details/[id]/page.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ViewDetails from "@/components/page/SupervisionReviews/ViewDetails";
+
+interface ReviewDetailsPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ReviewDetailsPage({
+  params,
+}: ReviewDetailsPageProps) {
+  const { id } = await params;
+
+  return <ViewDetails id={id} />;
+}

--- a/src/app/admin/supervision-reviews/page.tsx
+++ b/src/app/admin/supervision-reviews/page.tsx
@@ -1,0 +1,21 @@
+import React, { Suspense } from "react";
+import SupervisionReviews from "@/components/page/SupervisionReviews";
+import FullScreenSpinner from "@/components/ui/FullScreenSpinner";
+
+function SupervisionReviewsContent() {
+  return <SupervisionReviews />;
+}
+
+const SupervisionReviewsPage: React.FC = () => {
+  return (
+    <Suspense
+      fallback={
+        <FullScreenSpinner isVisible={true} message="Loading reviews..." />
+      }
+    >
+      <SupervisionReviewsContent />
+    </Suspense>
+  );
+};
+
+export default SupervisionReviewsPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/context/ThemeContext";
 import { ToastProvider } from "@/context/ToastContext";
 import { SubscriptionProvider } from "@/context/SubscriptionContext";
 import { UnlockRequestProvider } from "@/context/UnlockRequestContext";
+import { PendingSupervisorProvider } from "@/context/PendingSupervisorContext";
 import { ReduxProvider } from "@/store/ReduxProvider";
 import QueryProvider from "@/services/providers/QueryProvider";
 import ToastContainer from "@/components/ui/toast/ToastContainer";
@@ -28,7 +29,9 @@ export default function RootLayout({
               <ToastProvider>
                 <SubscriptionProvider>
                   <UnlockRequestProvider>
-                    <SidebarProvider>{children}</SidebarProvider>
+                    <PendingSupervisorProvider>
+                      <SidebarProvider>{children}</SidebarProvider>
+                    </PendingSupervisorProvider>
                   </UnlockRequestProvider>
                 </SubscriptionProvider>
                 <ToastContainer />

--- a/src/components/form/input/FileInput.tsx
+++ b/src/components/form/input/FileInput.tsx
@@ -1,16 +1,16 @@
 import React, { FC } from "react";
 
-interface FileInputProps {
+interface FileInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
   className?: string;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const FileInput: FC<FileInputProps> = ({ className, onChange }) => {
+const FileInput: FC<FileInputProps> = ({ className = "", onChange, ...props }) => {
   return (
     <input
       type="file"
       className={`focus:border-ring-brand-300 h-11 w-full overflow-hidden rounded-lg border border-gray-300 bg-transparent text-sm text-gray-500 shadow-theme-xs transition-colors file:mr-5 file:border-collapse file:cursor-pointer file:rounded-l-lg file:border-0 file:border-r file:border-solid file:border-gray-200 file:bg-gray-50 file:py-3 file:pl-3.5 file:pr-3 file:text-sm file:text-gray-700 placeholder:text-gray-400 hover:file:bg-gray-100 focus:outline-hidden focus:file:ring-brand-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:text-white/90 dark:file:border-gray-800 dark:file:bg-white/[0.03] dark:file:text-gray-400 dark:placeholder:text-gray-400 ${className}`}
       onChange={onChange}
+      {...props}
     />
   );
 };

--- a/src/components/form/input/TextArea.tsx
+++ b/src/components/form/input/TextArea.tsx
@@ -27,14 +27,14 @@ const TextArea: React.FC<TextareaProps> = ({
     }
   };
 
-  let textareaClasses = `w-full rounded-lg border px-4 py-2.5 text-sm shadow-theme-xs focus:outline-hidden ${className}`;
+  let textareaClasses = `w-full rounded-lg border px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:outline-hidden dark:placeholder:text-white/30 ${className}`;
 
   if (disabled) {
     textareaClasses += ` bg-gray-100 opacity-50 text-gray-500 border-gray-300 cursor-not-allowed dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700`;
   } else if (error) {
-    textareaClasses += ` bg-transparent text-gray-400 border-gray-300 focus:border-error-300 focus:ring-3 focus:ring-error-500/10 dark:border-gray-700 dark:bg-gray-900 dark:text-white/90 dark:focus:border-error-800`;
+    textareaClasses += ` bg-transparent text-gray-800 border-gray-300 focus:border-error-300 focus:ring-3 focus:ring-error-500/10 dark:border-gray-700 dark:bg-gray-900 dark:text-white/90 dark:focus:border-error-800`;
   } else {
-    textareaClasses += ` bg-transparent text-gray-400 border-gray-300 focus:border-brand-300 focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-gray-900 dark:text-white/90 dark:focus:border-brand-800`;
+    textareaClasses += ` bg-transparent text-gray-800 border-gray-300 focus:border-brand-300 focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-gray-900 dark:text-white/90 dark:focus:border-brand-800`;
   }
 
   return (

--- a/src/components/guards/PermissionGuard.tsx
+++ b/src/components/guards/PermissionGuard.tsx
@@ -76,8 +76,8 @@ const getPermissionForPath = (pathname: string): { permission: string; action: '
     return null; // Dashboard is always accessible
   }
 
-  // Supervisors are always accessible (no backend RBAC module yet for Find Supervisor)
-  if (pathname.startsWith('/admin/supervisors')) {
+  // Supervisors / supervisees are always accessible (no backend RBAC module yet for Find Supervisor)
+  if (pathname.startsWith('/admin/supervisors') || pathname.startsWith('/admin/supervisees')) {
     return null;
   }
   

--- a/src/components/page/Supervisee/ViewDetails/index.tsx
+++ b/src/components/page/Supervisee/ViewDetails/index.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Pencil } from "lucide-react";
+import { useSuperviseeDetails } from "@/services/hooks/useSupervisees";
+import { formatDate } from "@/services/utils/dateUtils";
+import { formatStateOfLicensureForDisplay, formatUsStateCodeForDisplay } from "@/services/utils/formatUsStateLicensure";
+import { formatUSPhoneNationalDisplay } from "@/services/utils/phoneNumberUtils";
+import {
+  BUDGET_TYPE_LABELS,
+  FORMAT_LABELS,
+  HOW_SOON_LABELS,
+} from "@/services/utils/superviseeProfileForm";
+import ErrorState from "../../../common/ErrorState";
+import FullScreenSpinner from "../../../ui/FullScreenSpinner";
+import BackToListButton from "@/components/ui/BackToListButton";
+import Badge from "@/components/ui/badge/Badge";
+import Avatar from "@/components/ui/avatar/Avatar";
+import { EditSuperviseeModal } from "../components/EditSuperviseeModal";
+
+interface ViewDetailsProps {
+  id: string;
+}
+
+function SectionCard({
+  title,
+  children,
+  titleAction,
+}: {
+  title: string;
+  children: React.ReactNode;
+  titleAction?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider">
+          {title}
+        </h3>
+        {titleAction ? <div className="flex shrink-0 items-center">{titleAction}</div> : null}
+      </div>
+      <div className="px-6 py-4">{children}</div>
+    </div>
+  );
+}
+
+function FieldRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start gap-1 py-2 border-b border-gray-50 dark:border-gray-700/50 last:border-0">
+      <span className="text-sm font-medium text-gray-500 dark:text-gray-400 sm:w-44 flex-shrink-0">
+        {label}
+      </span>
+      <span className="text-sm text-gray-900 dark:text-white flex-1">
+        {value || <span className="text-gray-400 italic">Not specified</span>}
+      </span>
+    </div>
+  );
+}
+
+export default function ViewDetails({ id }: ViewDetailsProps) {
+  const { data, isLoading, error, refetch } = useSuperviseeDetails(id);
+  const [editOpen, setEditOpen] = useState(false);
+
+  const displayName = useMemo(() => {
+    if (!data?.success || !data.data) return "";
+    const s = data.data;
+    return s.fullName || [s.firstName, s.lastName].filter(Boolean).join(" ") || s.userName;
+  }, [data]);
+
+  if (isLoading) {
+    return <FullScreenSpinner isVisible={true} message="Loading supervisee details..." />;
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 pt-4 pb-2">
+        <BackToListButton href="/admin/supervisees" className="mb-6" preserveState={true}>
+          Back to Supervisees
+        </BackToListButton>
+        <ErrorState message={`Error loading supervisee details: ${error.message}`} />
+      </div>
+    );
+  }
+
+  if (!data?.success || !data?.data) {
+    return (
+      <div className="px-4 pt-4 pb-2">
+        <BackToListButton href="/admin/supervisees" className="mb-6" preserveState={true}>
+          Back to Supervisees
+        </BackToListButton>
+        <div className="text-center py-8">
+          <p className="text-gray-500 dark:text-gray-400">Supervisee not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  const s = data.data;
+  const profile = s.superviseeProfile;
+  const location = [s.city, s.state, s.zipcode].filter(Boolean).join(", ");
+
+  const statesOfLicensureDisplay =
+    s.stateOfLicensure?.length > 0
+      ? s.stateOfLicensure.map(formatStateOfLicensureForDisplay).join(", ")
+      : null;
+
+  const statesLookingDisplay =
+    profile?.stateTheyAreLookingIn && profile.stateTheyAreLookingIn.length > 0
+      ? profile.stateTheyAreLookingIn.map(formatStateOfLicensureForDisplay).join(", ")
+      : null;
+
+  return (
+    <>
+      <div className="px-4 pt-4 pb-2">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+          <BackToListButton href="/admin/supervisees" preserveState={true}>
+            Back to Supervisees
+          </BackToListButton>
+
+          <button
+            type="button"
+            onClick={() => setEditOpen(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-brand-700 bg-brand-50 hover:bg-brand-100 dark:bg-brand-500/10 dark:text-brand-300 dark:hover:bg-brand-500/20 rounded-lg transition-colors"
+          >
+            <Pencil className="h-4 w-4 shrink-0" aria-hidden />
+            Edit supervisee
+          </button>
+        </div>
+
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 mb-6 flex flex-col sm:flex-row gap-5 items-start">
+          <Avatar src={s.profilePhotoUrl || undefined} name={displayName || "?"} size="xlarge" />
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-3 mb-1">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">{displayName || "—"}</h2>
+              <Badge variant="solid" color={s.emailVerified ? "success" : "warning"} size="sm">
+                {s.emailVerified ? "Email verified" : "Email unverified"}
+              </Badge>
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{s.email}</p>
+            {(profile?.superviseeOccupation || s.occupation?.name) && (
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                {[profile?.superviseeOccupation || s.occupation?.name, profile?.superviseeSpecialty || s.specialty?.name]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </p>
+            )}
+            {location && <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{location}</p>}
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          <SectionCard title="Basic Info">
+            <FieldRow label="Full Name" value={displayName} />
+            <FieldRow label="Email" value={s.email} />
+            <FieldRow
+              label="Phone"
+              value={
+                s.contactNumber ? formatUSPhoneNationalDisplay(s.contactNumber) : null
+              }
+            />
+            <FieldRow label="Username" value={s.userName} />
+            <FieldRow label="City" value={s.city} />
+            <FieldRow label="State" value={formatUsStateCodeForDisplay(s.state)} />
+            <FieldRow label="Zip Code" value={s.zipcode} />
+            <FieldRow label="Account Status" value={s.status} />
+            <FieldRow label="Active" value={s.isActive ? "Yes" : "No"} />
+            <FieldRow label="Registered" value={formatDate(s.createdAt)} />
+          </SectionCard>
+
+          <SectionCard title="Occupation & Licensure">
+            <FieldRow label="Occupation" value={s.occupation?.name} />
+            <FieldRow label="Specialty" value={s.specialty?.name} />
+            <FieldRow label="Credential / License Type" value={profile?.title} />
+            <FieldRow label="States of Licensure" value={statesOfLicensureDisplay} />
+          </SectionCard>
+
+          <SectionCard title="Supervision Needs">
+            <FieldRow
+              label="Type of Supervision Needed"
+              value={profile?.typeOfSupervisorNeeded?.join(", ")}
+            />
+            <FieldRow label="Occupation" value={profile?.superviseeOccupation} />
+            <FieldRow label="Specialty" value={profile?.superviseeSpecialty} />
+            <FieldRow
+              label="How Soon"
+              value={
+                profile?.howSoonLooking
+                  ? HOW_SOON_LABELS[profile.howSoonLooking] ?? profile.howSoonLooking
+                  : null
+              }
+            />
+            {profile?.howSoonLooking === "CUSTOM_DATE" && (
+              <FieldRow label="Looking Date" value={formatDate(profile.lookingDate)} />
+            )}
+            <FieldRow
+              label="Preferred Format"
+              value={
+                profile?.preferredFormat
+                  ? FORMAT_LABELS[profile.preferredFormat] ?? profile.preferredFormat
+                  : null
+              }
+            />
+            <FieldRow label="Availability" value={profile?.availability} />
+            <FieldRow label="States Looking In" value={statesLookingDisplay} />
+            <FieldRow
+              label="Budget"
+              value={
+                profile?.budgetRangeType
+                  ? `${BUDGET_TYPE_LABELS[profile.budgetRangeType] ?? profile.budgetRangeType}${
+                      profile.budgetRangeStart != null || profile.budgetRangeEnd != null
+                        ? ` — $${profile.budgetRangeStart ?? 0}–$${profile.budgetRangeEnd ?? 0}`
+                        : ""
+                    }`
+                  : null
+              }
+            />
+            <FieldRow
+              label="Ideal Supervisor"
+              value={
+                profile?.idealSupervisor ? (
+                  <span className="whitespace-pre-line">{profile.idealSupervisor}</span>
+                ) : null
+              }
+            />
+          </SectionCard>
+
+        </div>
+      </div>
+
+      <EditSuperviseeModal
+        isOpen={editOpen}
+        onClose={() => setEditOpen(false)}
+        superviseeId={id}
+        superviseeName={displayName || s.email}
+        onUpdate={() => refetch()}
+      />
+    </>
+  );
+}

--- a/src/components/page/Supervisee/components/EditSuperviseeModal.tsx
+++ b/src/components/page/Supervisee/components/EditSuperviseeModal.tsx
@@ -1,0 +1,595 @@
+"use client";
+
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { Modal } from "@/components/ui/modal";
+import Button from "@/components/ui/button/Button";
+import Input from "@/components/ui/input/Input";
+import Select from "@/components/form/Select";
+import MultiSelect from "@/components/form/MultiSelect";
+import USPhoneInput from "@/components/ui/USPhoneInput";
+import { FormField } from "@/components/ui/form";
+import Alert from "@/components/ui/alert/Alert";
+import ProfilePhotoUpload from "@/components/ui/ProfilePhotoUpload";
+import TextArea from "@/components/form/input/TextArea";
+import { superviseeApi } from "@/services/api/supervisee";
+import { useCitiesByState } from "@/lib/useStatesCities";
+import {
+  formDataToUpdatePayload,
+  mapSuperviseeDetailsToFormData,
+  validateSuperviseeEditForm,
+  type SuperviseeEditFormData,
+  type SuperviseeFieldErrors,
+} from "@/services/utils/superviseeProfileForm";
+import {
+  useUpdateSupervisee,
+  useSuperviseeFormOptions,
+  useSupervisorTypesData,
+  useSpecialtiesByOccupation,
+} from "@/services/hooks/useSupervisees";
+import { useStates } from "@/services/hooks/useStates";
+import { useOccupationsWithSpecialties } from "@/services/hooks/useJobCreation";
+
+interface EditSuperviseeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  superviseeId: string;
+  superviseeName?: string;
+  onUpdate: () => void;
+}
+
+const CREDENTIAL_TITLE_LABEL = "Credential or License Type";
+const CREDENTIAL_TITLE_PLACEHOLDER = "e.g. AMFT, LPC-Associate, ACSW, PA";
+
+const emptyForm = (): SuperviseeEditFormData => ({
+  fullName: "",
+  contactNumber: "",
+  city: "",
+  state: "",
+  zipcode: "",
+  occupation: "",
+  specialty: "",
+  title: "",
+  stateOfLicensure: [],
+  typeOfSupervisorNeeded: "",
+  superviseeOccupation: "",
+  superviseeSpecialty: "",
+  howSoonLooking: "",
+  lookingDate: "",
+  preferredFormat: "",
+  availability: "",
+  idealSupervisor: "",
+  stateTheyAreLookingIn: [],
+  budgetRangeType: "",
+  budgetRangeStart: "",
+  budgetRangeEnd: "",
+});
+
+type SelectChoice = { label: string; value: string };
+
+function choicesOnly(items: SelectChoice[]): SelectChoice[] {
+  return items.filter((o) => o.value !== "");
+}
+
+export const EditSuperviseeModal: React.FC<EditSuperviseeModalProps> = ({
+  isOpen,
+  onClose,
+  superviseeId,
+  superviseeName,
+  onUpdate,
+}) => {
+  const [formData, setFormData] = useState<SuperviseeEditFormData>(emptyForm);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<SuperviseeFieldErrors>({});
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [currentPhotoUrl, setCurrentPhotoUrl] = useState<string | null>(null);
+
+  const { mutate: updateMutate, isPending: isSaving } = useUpdateSupervisee();
+  const { formatOptions, howSoonOptions, availabilityOptions, budgetTypeOptions, isLoading: optionsLoading } =
+    useSuperviseeFormOptions();
+  const { data: supervisorTypesData = [], isLoading: supervisorTypesLoading } =
+    useSupervisorTypesData();
+  const { data: statesData, isLoading: statesLoading } = useStates();
+  const stateAbbr = formData.state?.trim() || null;
+  const { data: cities = [], isLoading: citiesLoading } = useCitiesByState(stateAbbr);
+  const { data: occupationsData } = useOccupationsWithSpecialties();
+  const { data: profileSpecialtyOptions = [], isLoading: profileSpecialtiesLoading } =
+    useSpecialtiesByOccupation(formData.occupation);
+
+  const stateOptions = useMemo(
+    () =>
+      statesData?.success && statesData.data
+        ? statesData.data.states.map((s) => ({ value: s.abbreviation, label: s.name }))
+        : [],
+    [statesData],
+  );
+
+  const stateMultiOptions = useMemo(
+    () => stateOptions.map((s) => ({ value: s.value, text: s.label, selected: false })),
+    [stateOptions],
+  );
+
+  const cityChoices = useMemo(() => {
+    const fromApi = cities.map((name) => ({ value: name, label: name }));
+    if (formData.city && !fromApi.some((o) => o.value === formData.city)) {
+      return choicesOnly([{ value: formData.city, label: formData.city }, ...fromApi]);
+    }
+    return choicesOnly(fromApi);
+  }, [cities, formData.city]);
+
+  const cityPlaceholder = useMemo(() => {
+    if (!formData.state) return "Select a state first";
+    if (citiesLoading) return "Loading…";
+    if (cityChoices.length === 0) return "No cities available";
+    return "Select city";
+  }, [formData.state, citiesLoading, cityChoices.length]);
+
+  const profileOccupationChoices = useMemo(
+    () =>
+      choicesOnly(
+        occupationsData?.success && occupationsData.data
+          ? occupationsData.data.map((o) => ({ value: o.id.toString(), label: o.name }))
+          : [],
+      ),
+    [occupationsData],
+  );
+
+  const profileSpecialtyChoices = useMemo(
+    () => choicesOnly(formData.occupation ? profileSpecialtyOptions : []),
+    [formData.occupation, profileSpecialtyOptions],
+  );
+
+  const profileSpecialtyPlaceholder = useMemo(() => {
+    if (!formData.occupation) return "Select an occupation first";
+    if (profileSpecialtiesLoading) return "Loading…";
+    if (profileSpecialtyOptions.length === 0) return "No specialties available";
+    return "Select specialty (optional)";
+  }, [formData.occupation, profileSpecialtiesLoading, profileSpecialtyOptions.length]);
+
+  const supervisorTypeChoices = useMemo(
+    () => choicesOnly(supervisorTypesData.map((t) => ({ label: t.name, value: t.name }))),
+    [supervisorTypesData],
+  );
+
+  const supervisionOccupationChoices = useMemo(() => {
+    if (!formData.typeOfSupervisorNeeded) return [];
+    const selectedType = supervisorTypesData.find(
+      (t) => t.name === formData.typeOfSupervisorNeeded,
+    );
+    return choicesOnly(
+      selectedType?.occupations.map((o) => ({ label: o.name, value: o.name })) ?? [],
+    );
+  }, [formData.typeOfSupervisorNeeded, supervisorTypesData]);
+
+  const supervisionOccupationPlaceholder = useMemo(() => {
+    if (!formData.typeOfSupervisorNeeded) return "Select a type of supervision first";
+    if (supervisionOccupationChoices.length === 0) return "No occupations available";
+    return "Select occupation";
+  }, [formData.typeOfSupervisorNeeded, supervisionOccupationChoices.length]);
+
+  const supervisionSpecialtyChoices = useMemo(() => {
+    if (!formData.typeOfSupervisorNeeded || !formData.superviseeOccupation) return [];
+    const selectedType = supervisorTypesData.find(
+      (t) => t.name === formData.typeOfSupervisorNeeded,
+    );
+    const selectedOccupation = selectedType?.occupations.find(
+      (o) => o.name === formData.superviseeOccupation,
+    );
+    return choicesOnly(
+      selectedOccupation?.specialties.map((s) => ({ label: s.name, value: s.name })) ?? [],
+    );
+  }, [
+    formData.typeOfSupervisorNeeded,
+    formData.superviseeOccupation,
+    supervisorTypesData,
+  ]);
+
+  const supervisionSpecialtyPlaceholder = useMemo(() => {
+    if (!formData.superviseeOccupation) return "Select an occupation first";
+    if (supervisionSpecialtyChoices.length === 0) return "No specialties available";
+    return "Select specialty";
+  }, [formData.superviseeOccupation, supervisionSpecialtyChoices.length]);
+
+  const handleClose = () => {
+    setSelectedFile(null);
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+    setCurrentPhotoUrl(null);
+    setLoadError(null);
+    setFieldErrors({});
+    setFormData(emptyForm());
+    onClose();
+  };
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const response = await superviseeApi.getSuperviseeById(superviseeId);
+      if (response.success && response.data) {
+        const statesList = statesData?.success ? statesData.data.states : [];
+        setFormData(mapSuperviseeDetailsToFormData(response.data, statesList));
+        setCurrentPhotoUrl(response.data.profilePhotoUrl);
+      }
+    } catch {
+      setLoadError("Failed to load supervisee data");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [superviseeId, statesData]);
+
+  useEffect(() => {
+    if (isOpen && superviseeId) loadData();
+  }, [isOpen, superviseeId, loadData]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const updateField = <K extends keyof SuperviseeEditFormData>(
+    field: K,
+    value: SuperviseeEditFormData[K],
+  ) => {
+    setFormData((prev) => {
+      const next = { ...prev, [field]: value };
+      if (field === "occupation") next.specialty = "";
+      if (field === "typeOfSupervisorNeeded") {
+        next.superviseeOccupation = "";
+        next.superviseeSpecialty = "";
+      }
+      if (field === "superviseeOccupation") next.superviseeSpecialty = "";
+      if (field === "state") next.city = "";
+      return next;
+    });
+    setFieldErrors((prev) => {
+      if (!prev[field]) return prev;
+      const { [field]: _, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  const handleFileSelect = (file: File) => {
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      setFieldErrors((prev) => ({
+        ...prev,
+        uploadProfilePhoto: "Please select a valid image file",
+      }));
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setFieldErrors((prev) => ({
+        ...prev,
+        uploadProfilePhoto: "File size must be less than 5MB",
+      }));
+      return;
+    }
+    setSelectedFile(file);
+    setPreviewUrl(URL.createObjectURL(file));
+    setFieldErrors((prev) => {
+      if (!prev.uploadProfilePhoto) return prev;
+      const { uploadProfilePhoto: _, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  const saveChanges = () => {
+    const errors = validateSuperviseeEditForm(formData);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+
+    const payload = formDataToUpdatePayload(formData, selectedFile ?? undefined);
+    updateMutate(
+      { id: superviseeId, payload },
+      {
+        onSuccess: () => {
+          onUpdate();
+          handleClose();
+        },
+      },
+    );
+  };
+
+  const isCustomDate = formData.howSoonLooking === "CUSTOM_DATE";
+  const optionsStillLoading = optionsLoading || supervisorTypesLoading;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      isFullscreen={false}
+      className="max-w-3xl mx-auto mt-8 mb-8 rounded-lg shadow-xl max-h-[90vh] overflow-y"
+    >
+      <div className="flex flex-col max-h-[90vh]">
+        <div className="p-6 pb-4 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Edit Supervisee</h2>
+          {superviseeName && (
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{superviseeName}</p>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {loadError && (
+            <div className="mb-4">
+              <Alert variant="error" title="Unable to load supervisee" message={loadError} />
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-brand-500" />
+              <span className="ml-2 text-gray-600 dark:text-gray-400">Loading...</span>
+            </div>
+          ) : (
+            <div className="space-y-8">
+              <FormField label="Profile photo" error={fieldErrors.uploadProfilePhoto}>
+                <ProfilePhotoUpload
+                  displayUrl={previewUrl || currentPhotoUrl}
+                  displayName={formData.fullName || superviseeName || "Supervisee"}
+                  hasPendingUpload={Boolean(selectedFile)}
+                  onFileSelect={handleFileSelect}
+                  disabled={isSaving}
+                />
+              </FormField>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider">
+                  Personal information
+                </h3>
+                <div className="grid grid-cols-1 gap-4">
+                  <FormField label="Full name" required error={fieldErrors.fullName}>
+                    <Input
+                      value={formData.fullName}
+                      onChange={(e) => updateField("fullName", e.target.value)}
+                      placeholder="Enter full name"
+                      error={!!fieldErrors.fullName}
+                    />
+                  </FormField>
+                  <FormField label="Contact number" required error={fieldErrors.contactNumber}>
+                    <USPhoneInput
+                      value={formData.contactNumber}
+                      onChange={(v) => updateField("contactNumber", v)}
+                      disabled={isSaving}
+                      error={!!fieldErrors.contactNumber}
+                    />
+                  </FormField>
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-[1fr_1fr_120px]">
+                  <FormField
+                    key={formData.state || "no-state"}
+                    label="City"
+                    required
+                    error={fieldErrors.city}
+                  >
+                    <Select
+                      value={formData.city}
+                      onChange={(v) => updateField("city", v)}
+                      options={cityChoices}
+                      placeholder={cityPlaceholder}
+                      disabled={!formData.state || citiesLoading}
+                    />
+                  </FormField>
+                  <FormField label="State" required error={fieldErrors.state}>
+                    <Select
+                      value={formData.state}
+                      onChange={(v) => updateField("state", v)}
+                      options={choicesOnly(stateOptions)}
+                      placeholder={statesLoading ? "Loading…" : "Select state"}
+                      disabled={statesLoading}
+                    />
+                  </FormField>
+                  <FormField label="Zipcode" required error={fieldErrors.zipcode}>
+                    <Input
+                      value={formData.zipcode}
+                      onChange={(e) => updateField("zipcode", e.target.value)}
+                      placeholder="ZIP"
+                      error={!!fieldErrors.zipcode}
+                    />
+                  </FormField>
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider">
+                  Occupation & licensure
+                </h3>
+                <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+                  The supervisee&apos;s own profession (stored on their account).
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField label="Occupation" required error={fieldErrors.occupation}>
+                    <Select
+                      value={formData.occupation}
+                      onChange={(v) => updateField("occupation", v)}
+                      options={profileOccupationChoices}
+                      placeholder="Select occupation"
+                    />
+                  </FormField>
+                  <FormField label="Specialty">
+                    <Select
+                      value={formData.specialty}
+                      onChange={(v) => updateField("specialty", v)}
+                      options={profileSpecialtyChoices}
+                      placeholder={profileSpecialtyPlaceholder}
+                    />
+                  </FormField>
+                  <FormField
+                    className="sm:col-span-2"
+                    label={CREDENTIAL_TITLE_LABEL}
+                    required
+                    error={fieldErrors.title}
+                  >
+                    <Input
+                      value={formData.title}
+                      onChange={(e) => updateField("title", e.target.value)}
+                      placeholder={CREDENTIAL_TITLE_PLACEHOLDER}
+                      error={!!fieldErrors.title}
+                    />
+                  </FormField>
+                </div>
+                <FormField label="States of licensure" required error={fieldErrors.stateOfLicensure}>
+                  <MultiSelect
+                    label=""
+                    options={stateMultiOptions}
+                    value={formData.stateOfLicensure}
+                    onChange={(selected) => updateField("stateOfLicensure", selected)}
+                    placeholder="Select states..."
+                  />
+                </FormField>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider">
+                  Supervision needs
+                </h3>
+                <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+                  What kind of supervisor they are looking for (same options as signup).
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    className="sm:col-span-2"
+                    label="Type of supervision needed"
+                    required
+                    error={fieldErrors.typeOfSupervisorNeeded}
+                  >
+                    <Select
+                      value={formData.typeOfSupervisorNeeded}
+                      onChange={(v) => updateField("typeOfSupervisorNeeded", v)}
+                      options={supervisorTypeChoices}
+                      placeholder={
+                        supervisorTypesLoading ? "Loading…" : "Select type of supervision"
+                      }
+                    />
+                  </FormField>
+                  <FormField label="Occupation" required error={fieldErrors.superviseeOccupation}>
+                    <Select
+                      value={formData.superviseeOccupation}
+                      onChange={(v) => updateField("superviseeOccupation", v)}
+                      options={supervisionOccupationChoices}
+                      placeholder={supervisionOccupationPlaceholder}
+                    />
+                  </FormField>
+                  <FormField label="Specialty">
+                    <Select
+                      value={formData.superviseeSpecialty}
+                      onChange={(v) => updateField("superviseeSpecialty", v)}
+                      options={supervisionSpecialtyChoices}
+                      placeholder={supervisionSpecialtyPlaceholder}
+                    />
+                  </FormField>
+                  <FormField
+                    label="How soon do you need supervision?"
+                    required
+                    error={fieldErrors.howSoonLooking}
+                  >
+                    <Select
+                      value={formData.howSoonLooking}
+                      onChange={(v) => updateField("howSoonLooking", v)}
+                      options={choicesOnly(howSoonOptions)}
+                      placeholder={optionsStillLoading ? "Loading…" : "Select timeline"}
+                    />
+                  </FormField>
+                  {isCustomDate && (
+                    <FormField label="Looking date" required error={fieldErrors.lookingDate}>
+                      <Input
+                        type="date"
+                        value={formData.lookingDate}
+                        onChange={(e) => updateField("lookingDate", e.target.value)}
+                        error={!!fieldErrors.lookingDate}
+                      />
+                    </FormField>
+                  )}
+                  <FormField label="Preferred format" required error={fieldErrors.preferredFormat}>
+                    <Select
+                      value={formData.preferredFormat}
+                      onChange={(v) => updateField("preferredFormat", v)}
+                      options={choicesOnly(formatOptions)}
+                      placeholder="Select format"
+                    />
+                  </FormField>
+                  <FormField label="Availability" required error={fieldErrors.availability}>
+                    <Select
+                      value={formData.availability}
+                      onChange={(v) => updateField("availability", v)}
+                      options={choicesOnly(availabilityOptions)}
+                      placeholder="Select availability"
+                    />
+                  </FormField>
+                  <FormField label="Budget type" required error={fieldErrors.budgetRangeType}>
+                    <Select
+                      value={formData.budgetRangeType}
+                      onChange={(v) => updateField("budgetRangeType", v)}
+                      options={choicesOnly(budgetTypeOptions)}
+                      placeholder="Select budget type"
+                    />
+                  </FormField>
+                  <FormField label="Budget start ($)" required error={fieldErrors.budgetRangeStart}>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={formData.budgetRangeStart}
+                      onChange={(e) => updateField("budgetRangeStart", e.target.value)}
+                      error={!!fieldErrors.budgetRangeStart}
+                    />
+                  </FormField>
+                  <FormField label="Budget end ($)" required error={fieldErrors.budgetRangeEnd}>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={formData.budgetRangeEnd}
+                      onChange={(e) => updateField("budgetRangeEnd", e.target.value)}
+                      error={!!fieldErrors.budgetRangeEnd}
+                    />
+                  </FormField>
+                </div>
+                <FormField
+                  label="States they are looking in"
+                  required
+                  error={fieldErrors.stateTheyAreLookingIn}
+                >
+                  <MultiSelect
+                    label=""
+                    options={stateMultiOptions}
+                    value={formData.stateTheyAreLookingIn}
+                    onChange={(selected) => updateField("stateTheyAreLookingIn", selected)}
+                    placeholder="Select states..."
+                  />
+                </FormField>
+                <FormField
+                  label="Description of ideal supervisor"
+                  required
+                  error={fieldErrors.idealSupervisor}
+                >
+                  <TextArea
+                    value={formData.idealSupervisor}
+                    onChange={(v) => updateField("idealSupervisor", v)}
+                    rows={4}
+                    placeholder="Describe ideal supervisor…"
+                    error={!!fieldErrors.idealSupervisor}
+                  />
+                </FormField>
+              </section>
+            </div>
+          )}
+        </div>
+
+        <div className="p-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-3">
+          <Button variant="outline" onClick={handleClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={saveChanges} disabled={isLoading || isSaving}>
+            {isSaving ? "Saving..." : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default EditSuperviseeModal;

--- a/src/components/page/Supervisee/components/SuperviseeHeader.tsx
+++ b/src/components/page/Supervisee/components/SuperviseeHeader.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Input from "../../../ui/input/Input";
+import { SearchIcon } from "../../../ui/icons";
+import { SuperviseeHeaderProps } from "@/services/types/SuperviseeTypes";
+
+const SuperviseeHeader: React.FC<SuperviseeHeaderProps> = ({
+  totalCount,
+  isPending,
+  searchInput,
+  setSearchInput,
+}) => {
+  return (
+    <div className="px-6 py-5 border-b border-gray-200 dark:border-gray-800">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h3 className="text-xl font-semibold text-gray-800 dark:text-white">Supervisees</h3>
+          <p className="text-sm text-gray-500 mt-1 dark:text-gray-400">
+            {totalCount || 0} total supervisees
+            {isPending && <span className="ml-2 text-xs text-primary">Updating...</span>}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <SearchIcon className="h-4 w-4" />
+          </div>
+          <Input
+            type="text"
+            placeholder="Search by name, email, or phone..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            className={`w-full pl-10 ${searchInput ? "pr-10" : ""}`}
+          />
+          {searchInput && (
+            <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
+              <button
+                type="button"
+                onClick={() => setSearchInput("")}
+                className="text-gray-400 hover:text-gray-600 dark:text-gray-300 dark:hover:text-white transition-colors"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SuperviseeHeader;

--- a/src/components/page/Supervisee/components/SuperviseeTable.tsx
+++ b/src/components/page/Supervisee/components/SuperviseeTable.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { Eye, Pencil } from "lucide-react";
+import { formatDate } from "@/services/utils/dateUtils";
+import { formatUsStateCodeForDisplay } from "@/services/utils/formatUsStateLicensure";
+import { formatUSPhoneNationalDisplay } from "@/services/utils/phoneNumberUtils";
+import {
+  FORMAT_LABELS,
+  HOW_SOON_LABELS,
+} from "@/services/utils/superviseeProfileForm";
+import { Table, TableBody, TableCell, TableRow } from "../../../ui/table";
+import Avatar from "../../../ui/avatar/Avatar";
+import TableHeading from "../../../tables/tableHeader";
+import Badge from "../../../ui/badge/Badge";
+import { SuperviseeTableProps } from "@/services/types/SuperviseeTypes";
+
+const ACTION_ICON_PX = 16;
+const actionIconProps = { size: ACTION_ICON_PX, className: "shrink-0" } as const;
+
+const SuperviseeTable: React.FC<SuperviseeTableProps> = ({
+  data,
+  isLoading,
+  tableColumns,
+  onViewSupervisee,
+  onEditSupervisee,
+}) => {
+  return (
+    <div className="overflow-x-auto">
+      <Table className="min-w-full">
+        <TableHeading columns={tableColumns} />
+        <TableBody>
+          {isLoading ? (
+            <TableRow>
+              <TableCell
+                colSpan={tableColumns.length}
+                className="py-12 text-center text-sm text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex items-center justify-center gap-2">
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-brand-500" />
+                  Loading supervisees...
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : !data?.data?.length ? (
+            <TableRow>
+              <TableCell
+                colSpan={tableColumns.length}
+                className="py-12 text-center text-sm text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex flex-col items-center gap-2">
+                  <span>No supervisees found</span>
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : (
+            data.data.map((supervisee) => (
+              <TableRow
+                key={supervisee.id}
+                className="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-white/[0.02] transition-colors"
+              >
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <div className="flex items-center gap-3">
+                    <Avatar
+                      src={supervisee.profilePhotoUrl || undefined}
+                      name={supervisee.fullName || "?"}
+                      size="small"
+                    />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate max-w-[160px]">
+                        {supervisee.fullName || "—"}
+                      </p>
+                      {supervisee.contactNumber && (
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {formatUSPhoneNationalDisplay(supervisee.contactNumber)}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </TableCell>
+
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  {supervisee.email}
+                </TableCell>
+
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  {formatUsStateCodeForDisplay(supervisee.state) || (
+                    <span className="text-gray-400 italic">—</span>
+                  )}
+                </TableCell>
+
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  {supervisee.preferredFormat
+                    ? FORMAT_LABELS[supervisee.preferredFormat] ?? supervisee.preferredFormat
+                    : <span className="text-gray-400 italic">—</span>}
+                </TableCell>
+
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  {supervisee.howSoonLooking
+                    ? HOW_SOON_LABELS[supervisee.howSoonLooking] ?? supervisee.howSoonLooking
+                    : <span className="text-gray-400 italic">—</span>}
+                </TableCell>
+
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <Badge
+                    variant="solid"
+                    color={supervisee.emailVerified ? "success" : "warning"}
+                    size="sm"
+                  >
+                    {supervisee.emailVerified ? "Verified" : "Unverified"}
+                  </Badge>
+                </TableCell>
+
+                <TableCell className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {formatDate(supervisee.createdAt)}
+                </TableCell>
+
+                <TableCell className="px-4 py-3 whitespace-nowrap text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <button
+                      onClick={() => onViewSupervisee(supervisee.id)}
+                      title="View details"
+                      className="p-1.5 text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400 rounded transition-colors"
+                    >
+                      <Eye {...actionIconProps} />
+                    </button>
+                    <button
+                      onClick={() =>
+                        onEditSupervisee(supervisee.id, supervisee.fullName || supervisee.email)
+                      }
+                      title="Edit supervisee"
+                      className="p-1.5 text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400 rounded transition-colors"
+                    >
+                      <Pencil {...actionIconProps} />
+                    </button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default SuperviseeTable;

--- a/src/components/page/Supervisee/components/SuperviseeTablePagination.tsx
+++ b/src/components/page/Supervisee/components/SuperviseeTablePagination.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import Pagination from "../../../tables/Pagination";
+import Select from "../../../form/Select";
+import { SuperviseeTablePaginationProps } from "@/services/types/SuperviseeTypes";
+
+const SuperviseeTablePagination: React.FC<SuperviseeTablePaginationProps> = ({
+  data,
+  filters,
+  onPageChange,
+  itemsPerPageOptions,
+  onFilterChange,
+}) => {
+  if (!data?.success || !data?.data?.length || !data?.metaData) {
+    return null;
+  }
+
+  const { metaData } = data;
+  const limit = filters.limit || 10;
+
+  return (
+    <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-800">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          Showing {((metaData.page - 1) * limit) + 1} to{" "}
+          {Math.min(metaData.page * limit, metaData.totalCount)} of {metaData.totalCount} results
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+              Items per page:
+            </span>
+            <Select
+              value={limit.toString()}
+              onChange={(value: string) => onFilterChange("limit", parseInt(value))}
+              options={itemsPerPageOptions}
+              className="w-auto min-w-[120px]"
+            />
+          </div>
+          <Pagination
+            currentPage={metaData.page}
+            totalPages={metaData.totalPages}
+            onPageChange={onPageChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SuperviseeTablePagination;

--- a/src/components/page/Supervisee/components/index.ts
+++ b/src/components/page/Supervisee/components/index.ts
@@ -1,0 +1,4 @@
+export { default as SuperviseeHeader } from "./SuperviseeHeader";
+export { default as SuperviseeTable } from "./SuperviseeTable";
+export { default as SuperviseeTablePagination } from "./SuperviseeTablePagination";
+export { EditSuperviseeModal } from "./EditSuperviseeModal";

--- a/src/components/page/Supervisee/index.tsx
+++ b/src/components/page/Supervisee/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React from "react";
+import { BoltIcon } from "@/icons";
+import ErrorState from "../../common/ErrorState";
+import { useSuperviseeLogic } from "@/services/hooks/useSuperviseeLogic";
+import { usePreservedNavigation } from "@/hooks/usePreservedNavigation";
+import { SuperviseesProps } from "@/services/types/SuperviseeTypes";
+import {
+  SuperviseeHeader,
+  SuperviseeTable,
+  SuperviseeTablePagination,
+  EditSuperviseeModal,
+} from "./components";
+
+const Supervisees: React.FC<SuperviseesProps> = ({ className = "" }) => {
+  usePreservedNavigation({
+    statePath: "supervisee-search-state",
+    scrollPath: "supervisee-scroll-position",
+    listPagePath: "/admin/supervisees",
+  });
+
+  const {
+    filters,
+    searchInput,
+    setSearchInput,
+    isPending,
+    data,
+    isLoading,
+    error,
+    refetch,
+    tableColumns,
+    itemsPerPageOptions,
+    filterChange,
+    initPageChange,
+    viewSupervisee,
+    editModal,
+    openEditModal,
+    closeEditModal,
+  } = useSuperviseeLogic();
+
+  if (error && !isPending) {
+    return (
+      <ErrorState
+        className={className}
+        message={`Error loading supervisees: ${error.message}`}
+        onRetry={() => refetch()}
+        retryIcon={<BoltIcon />}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div
+        className={`rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] ${className}`}
+      >
+        <SuperviseeHeader
+          totalCount={data?.metaData?.totalCount || 0}
+          isPending={isPending}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+        />
+
+        <SuperviseeTable
+          data={data}
+          isLoading={isLoading}
+          tableColumns={tableColumns}
+          onViewSupervisee={viewSupervisee}
+          onEditSupervisee={openEditModal}
+        />
+
+        <SuperviseeTablePagination
+          data={data}
+          filters={filters}
+          onPageChange={initPageChange}
+          itemsPerPageOptions={itemsPerPageOptions}
+          onFilterChange={filterChange}
+        />
+      </div>
+
+      <EditSuperviseeModal
+        isOpen={editModal.isOpen}
+        onClose={closeEditModal}
+        superviseeId={editModal.superviseeId}
+        superviseeName={editModal.fullName}
+        onUpdate={() => refetch()}
+      />
+    </>
+  );
+};
+
+export default Supervisees;

--- a/src/components/page/SupervisionReviews/ViewDetails/index.tsx
+++ b/src/components/page/SupervisionReviews/ViewDetails/index.tsx
@@ -1,0 +1,303 @@
+"use client";
+import React, { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  useSupervisionReviewDetails,
+  useDeleteSupervisionReview,
+} from "@/services/hooks/useSupervisionReviews";
+import { formatDate } from "@/services/utils/dateUtils";
+import ErrorState from "../../../common/ErrorState";
+import FullScreenSpinner from "../../../ui/FullScreenSpinner";
+import BackToListButton from "@/components/ui/BackToListButton";
+import Avatar from "@/components/ui/avatar/Avatar";
+import ConfirmationDialog from "@/components/ui/ConfirmationDialog";
+import { StarRating } from "../components";
+
+interface ViewDetailsProps {
+  id: string;
+}
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+      <div className="px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider">
+          {title}
+        </h3>
+      </div>
+      <div className="px-6 py-4">{children}</div>
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start gap-1 py-2 border-b border-gray-50 dark:border-gray-700/50 last:border-0">
+      <span className="text-sm font-medium text-gray-500 dark:text-gray-400 sm:w-44 flex-shrink-0">
+        {label}
+      </span>
+      <span className="text-sm text-gray-900 dark:text-white flex-1">
+        {value || <span className="text-gray-400 italic">Not specified</span>}
+      </span>
+    </div>
+  );
+}
+
+const HireStatusBadge: React.FC<{ status: string }> = ({ status }) => {
+  const colors: Record<string, string> = {
+    COMPLETED:
+      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+    ACTIVE:
+      "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+    CANCELLED:
+      "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+    PENDING:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors[status] || "bg-gray-100 text-gray-600"}`}
+    >
+      {status}
+    </span>
+  );
+};
+
+export default function ViewDetails({ id }: ViewDetailsProps) {
+  const router = useRouter();
+  const { data, isLoading, error } = useSupervisionReviewDetails(id);
+  const { mutateAsync: deleteReview, isPending: isDeleting } =
+    useDeleteSupervisionReview();
+
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  const handleDelete = async () => {
+    await deleteReview(id);
+    setDeleteDialogOpen(false);
+    router.push("/admin/supervision-reviews");
+  };
+
+  if (isLoading) {
+    return (
+      <FullScreenSpinner isVisible={true} message="Loading review details..." />
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 pt-4 pb-2">
+        <BackToListButton href="/admin/supervision-reviews" className="mb-6">
+          Back to Reviews
+        </BackToListButton>
+        <ErrorState
+          message={`Error loading review details: ${error.message}`}
+        />
+      </div>
+    );
+  }
+
+  if (!data?.success || !data?.data) {
+    return (
+      <div className="px-4 pt-4 pb-2">
+        <BackToListButton href="/admin/supervision-reviews" className="mb-6">
+          Back to Reviews
+        </BackToListButton>
+        <div className="text-center py-8">
+          <p className="text-gray-500 dark:text-gray-400">Review not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  const review = data.data;
+
+  return (
+    <>
+      <div className="px-4 pt-4 pb-8">
+        {/* Top bar */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+          <BackToListButton href="/admin/supervision-reviews">
+            Back to Reviews
+          </BackToListButton>
+
+          <button
+            onClick={() => setDeleteDialogOpen(true)}
+            disabled={isDeleting}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-error-700 bg-error-50 hover:bg-error-100 dark:bg-error-500/10 dark:text-error-400 dark:hover:bg-error-500/20 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <Trash2 className="h-4 w-4 shrink-0" />
+            Delete Review
+          </button>
+        </div>
+
+        {/* Hero rating card */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6 mb-6">
+          <div className="flex flex-col sm:flex-row gap-6 items-start">
+            {/* Supervisee */}
+            <div className="flex items-center gap-3 flex-1 min-w-0">
+              <Avatar
+                src={review.supervisee?.profilePhotoUrl || undefined}
+                name={review.supervisee?.fullName || "?"}
+                size="xlarge"
+              />
+              <div className="min-w-0">
+                <p className="text-xs text-gray-400 uppercase font-medium mb-0.5">
+                  Supervisee
+                </p>
+                <p className="text-base font-semibold text-gray-900 dark:text-white truncate">
+                  {review.supervisee?.fullName || "—"}
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                  {review.supervisee?.email}
+                </p>
+              </div>
+            </div>
+
+            {/* Arrow divider */}
+            <div className="hidden sm:flex items-center self-center text-gray-300 dark:text-gray-600">
+              <svg
+                className="w-6 h-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M17 8l4 4m0 0l-4 4m4-4H3"
+                />
+              </svg>
+            </div>
+
+            {/* Supervisor */}
+            <div className="flex items-center gap-3 flex-1 min-w-0">
+              <Avatar
+                src={review.supervisor?.profilePhotoUrl || undefined}
+                name={review.supervisor?.fullName || "?"}
+                size="xlarge"
+              />
+              <div className="min-w-0">
+                <p className="text-xs text-gray-400 uppercase font-medium mb-0.5">
+                  Supervisor
+                </p>
+                <p className="text-base font-semibold text-gray-900 dark:text-white truncate">
+                  {review.supervisor?.fullName || "—"}
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                  {review.supervisor?.email}
+                </p>
+              </div>
+            </div>
+
+            {/* Rating */}
+            <div className="flex flex-col items-start sm:items-end gap-1 self-center">
+              <p className="text-xs text-gray-400 uppercase font-medium">
+                Rating
+              </p>
+              <StarRating rating={review.rating} />
+            </div>
+          </div>
+
+          {/* Comment */}
+          {review.comment && (
+            <div className="mt-5 pt-5 border-t border-gray-100 dark:border-gray-700">
+              <p className="text-xs text-gray-400 uppercase font-medium mb-2">
+                Comment
+              </p>
+              <p className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-line leading-relaxed">
+                {review.comment}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-5">
+          {/* Hire details */}
+          {review.hire && (
+            <SectionCard title="Hire Details">
+              <FieldRow
+                label="Status"
+                value={<HireStatusBadge status={review.hire.status} />}
+              />
+              <FieldRow
+                label="Start Date"
+                value={formatDate(review.hire.startDate)}
+              />
+              <FieldRow
+                label="End Date"
+                value={formatDate(review.hire.endDate)}
+              />
+              <FieldRow
+                label="Hired On"
+                value={formatDate(review.hire.createdAt)}
+              />
+            </SectionCard>
+          )}
+
+          {/* Supervisee info */}
+          <SectionCard title="Supervisee Info">
+            <FieldRow
+              label="Full Name"
+              value={review.supervisee?.fullName}
+            />
+            <FieldRow label="Email" value={review.supervisee?.email} />
+            <FieldRow
+              label="Location"
+              value={
+                [review.supervisee?.city, review.supervisee?.state]
+                  .filter(Boolean)
+                  .join(", ") || null
+              }
+            />
+            <FieldRow
+              label="Occupation"
+              value={review.supervisee?.occupation?.name}
+            />
+          </SectionCard>
+
+          {/* Supervisor info */}
+          <SectionCard title="Supervisor Info">
+            <FieldRow
+              label="Full Name"
+              value={review.supervisor?.fullName}
+            />
+            <FieldRow label="Email" value={review.supervisor?.email} />
+          </SectionCard>
+
+          {/* Review metadata */}
+          <SectionCard title="Review Metadata">
+            <FieldRow label="Review ID" value={review.id} />
+            <FieldRow label="Submitted" value={formatDate(review.createdAt)} />
+            <FieldRow label="Last Updated" value={formatDate(review.updatedAt)} />
+          </SectionCard>
+        </div>
+      </div>
+
+      <ConfirmationDialog
+        isOpen={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteDialogOpen(false)}
+        title="Delete Review"
+        message="Are you sure you want to permanently delete this review? This action cannot be undone."
+        confirmText="Delete"
+        cancelText="Cancel"
+        isLoading={isDeleting}
+      />
+    </>
+  );
+}

--- a/src/components/page/SupervisionReviews/components/ReviewFilters.tsx
+++ b/src/components/page/SupervisionReviews/components/ReviewFilters.tsx
@@ -1,0 +1,52 @@
+"use client";
+import React from "react";
+import Select from "../../../form/Select";
+import { SupervisionReviewFilters } from "@/services/types/supervisionReview";
+
+interface ReviewFiltersProps {
+  filters: SupervisionReviewFilters;
+  onFilterChange: (key: keyof SupervisionReviewFilters, value: unknown) => void;
+  ratingOptions: { value: string; label: string }[];
+  hasActiveFilters: boolean;
+  clearIndividualFilter: (key: keyof SupervisionReviewFilters) => void;
+}
+
+const ReviewFilters: React.FC<ReviewFiltersProps> = ({
+  filters,
+  onFilterChange,
+  ratingOptions,
+}) => {
+  return (
+    <div className="space-y-4 p-1">
+      <div>
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Min Rating
+        </label>
+        <Select
+          value={filters.minRating?.toString() || ""}
+          onChange={(value: string) =>
+            onFilterChange("minRating", value ? parseInt(value, 10) : undefined)
+          }
+          options={[{ value: "", label: "Any" }, ...ratingOptions]}
+          className="w-full"
+        />
+      </div>
+
+      <div>
+        <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Max Rating
+        </label>
+        <Select
+          value={filters.maxRating?.toString() || ""}
+          onChange={(value: string) =>
+            onFilterChange("maxRating", value ? parseInt(value, 10) : undefined)
+          }
+          options={[{ value: "", label: "Any" }, ...ratingOptions]}
+          className="w-full"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ReviewFilters;

--- a/src/components/page/SupervisionReviews/components/ReviewHeader.tsx
+++ b/src/components/page/SupervisionReviews/components/ReviewHeader.tsx
@@ -1,0 +1,138 @@
+"use client";
+import React, { useRef } from "react";
+import Input from "../../../ui/input/Input";
+import FilterDropdown from "../../../ui/FilterDropdown";
+import { SearchIcon, FilterIcon } from "../../../ui/icons";
+
+interface ReviewHeaderProps {
+  totalCount: number;
+  isPending: boolean;
+  isLoading: boolean;
+  searchInput: string;
+  setSearchInput: (value: string) => void;
+  applyKeywordSearch: (value: string) => void;
+  isFilterOpen: boolean;
+  setIsFilterOpen: (open: boolean) => void;
+  onRefetch: () => void;
+  onClearFilters: () => void;
+  hasActiveFilters: boolean;
+  filterDropdownContent?: React.ReactNode;
+}
+
+const ReviewHeader: React.FC<ReviewHeaderProps> = ({
+  totalCount,
+  isPending,
+  searchInput,
+  setSearchInput,
+  applyKeywordSearch,
+  isFilterOpen,
+  setIsFilterOpen,
+  onClearFilters,
+  hasActiveFilters,
+  filterDropdownContent,
+}) => {
+  const filterButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      applyKeywordSearch(searchInput);
+    }
+  };
+
+  return (
+    <div className="px-6 py-5 border-b border-gray-200 dark:border-gray-800">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex items-center justify-between w-full">
+          <div>
+            <h3 className="text-xl font-semibold text-gray-800 dark:text-white">
+              Supervisor Reviews
+            </h3>
+            <p className="text-sm text-gray-500 mt-1 dark:text-gray-400">
+              {totalCount || 0} total reviews
+              {isPending && (
+                <span className="ml-2 text-xs text-primary">Updating...</span>
+              )}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              ref={filterButtonRef}
+              onClick={() => setIsFilterOpen(!isFilterOpen)}
+              className={`
+                flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border transition-colors
+                ${
+                  isFilterOpen
+                    ? "bg-primary/10 border-primary/20 text-primary"
+                    : "bg-white border-gray-200 text-gray-700 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-700"
+                }
+              `}
+            >
+              <FilterIcon />
+              <span>Filter</span>
+              {hasActiveFilters && (
+                <span className="ml-1 bg-primary text-white text-xs rounded-full px-1.5 py-0.5 min-w-[18px] h-4 flex items-center justify-center font-medium" />
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <SearchIcon className="h-4 w-4" />
+          </div>
+          <Input
+            type="text"
+            placeholder="Search by supervisor name, supervisee name, or comment..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className={`w-full pl-10 ${searchInput ? "pr-10" : ""}`}
+          />
+          {searchInput && (
+            <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchInput("");
+                  applyKeywordSearch("");
+                }}
+                className="text-gray-400 hover:text-gray-600 dark:text-gray-300 dark:hover:text-white transition-colors"
+              >
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {filterDropdownContent && (
+        <FilterDropdown
+          isOpen={isFilterOpen}
+          onClose={() => setIsFilterOpen(false)}
+          triggerRef={filterButtonRef}
+          onClearAll={onClearFilters}
+          hasActiveFilters={hasActiveFilters}
+        >
+          {filterDropdownContent}
+        </FilterDropdown>
+      )}
+    </div>
+  );
+};
+
+export default ReviewHeader;

--- a/src/components/page/SupervisionReviews/components/ReviewTable.tsx
+++ b/src/components/page/SupervisionReviews/components/ReviewTable.tsx
@@ -1,0 +1,197 @@
+"use client";
+import React from "react";
+import { Eye, Trash2 } from "lucide-react";
+import { formatDate } from "@/services/utils/dateUtils";
+import { Table, TableBody, TableCell, TableRow } from "../../../ui/table";
+import Avatar from "../../../ui/avatar/Avatar";
+import TableHeading from "../../../tables/tableHeader";
+import StarRating from "./StarRating";
+import {
+  SupervisionReview,
+  SupervisionReviewsResponse,
+} from "@/services/types/supervisionReview";
+
+const ACTION_ICON_PX = 16;
+const actionIconProps = {
+  size: ACTION_ICON_PX,
+  className: "shrink-0",
+} as const;
+
+interface ReviewTableProps {
+  data: SupervisionReviewsResponse | undefined;
+  isLoading: boolean;
+  tableColumns: { key: string; label: string; className?: string }[];
+  onViewReview: (reviewId: string) => void;
+  onDeleteReview: (reviewId: string, comment: string | null) => void;
+}
+
+const HireStatusBadge: React.FC<{ status: string }> = ({ status }) => {
+  const colors: Record<string, string> = {
+    COMPLETED: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+    ACTIVE: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+    CANCELLED: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+    PENDING: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${colors[status] || "bg-gray-100 text-gray-600"}`}
+    >
+      {status}
+    </span>
+  );
+};
+
+const ReviewTable: React.FC<ReviewTableProps> = ({
+  data,
+  isLoading,
+  tableColumns,
+  onViewReview,
+  onDeleteReview,
+}) => {
+  return (
+    <div className="overflow-x-auto">
+      <Table className="min-w-full">
+        <TableHeading columns={tableColumns} />
+        <TableBody>
+          {isLoading ? (
+            <TableRow>
+              <TableCell
+                colSpan={tableColumns.length}
+                className="py-12 text-center text-sm text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex items-center justify-center gap-2">
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-brand-500" />
+                  Loading reviews...
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : !data?.data?.length ? (
+            <TableRow>
+              <TableCell
+                colSpan={tableColumns.length}
+                className="py-12 text-center text-sm text-gray-500 dark:text-gray-400"
+              >
+                <div className="flex flex-col items-center gap-2">
+                  <svg
+                    className="h-10 w-10 text-gray-300 dark:text-gray-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+                    />
+                  </svg>
+                  <span>No reviews found</span>
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : (
+            data.data.map((review: SupervisionReview) => (
+              <TableRow
+                key={review.id}
+                className="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-white/[0.02] transition-colors"
+              >
+                {/* Supervisee */}
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <div className="flex items-center gap-3">
+                    <Avatar
+                      src={review.supervisee?.profilePhotoUrl || undefined}
+                      name={review.supervisee?.fullName || "?"}
+                      size="small"
+                    />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate max-w-[140px]">
+                        {review.supervisee?.fullName || "—"}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[140px]">
+                        {review.supervisee?.email}
+                      </p>
+                    </div>
+                  </div>
+                </TableCell>
+
+                {/* Supervisor */}
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <div className="flex items-center gap-3">
+                    <Avatar
+                      src={review.supervisor?.profilePhotoUrl || undefined}
+                      name={review.supervisor?.fullName || "?"}
+                      size="small"
+                    />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate max-w-[140px]">
+                        {review.supervisor?.fullName || "—"}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[140px]">
+                        {review.supervisor?.email}
+                      </p>
+                    </div>
+                  </div>
+                </TableCell>
+
+                {/* Rating */}
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <StarRating rating={review.rating} />
+                </TableCell>
+
+                {/* Comment */}
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 max-w-[220px]">
+                  {review.comment ? (
+                    <p className="truncate" title={review.comment}>
+                      {review.comment}
+                    </p>
+                  ) : (
+                    <span className="text-gray-400 italic text-xs">
+                      No comment
+                    </span>
+                  )}
+                </TableCell>
+
+                {/* Hire Status */}
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  {review.hire ? (
+                    <HireStatusBadge status={review.hire.status} />
+                  ) : (
+                    <span className="text-gray-400 italic text-xs">—</span>
+                  )}
+                </TableCell>
+
+                {/* Submitted */}
+                <TableCell className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                  {formatDate(review.createdAt)}
+                </TableCell>
+
+                {/* Actions */}
+                <TableCell className="px-4 py-3 whitespace-nowrap text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <button
+                      onClick={() => onViewReview(review.id)}
+                      title="View details"
+                      className="p-1.5 text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400 rounded transition-colors"
+                    >
+                      <Eye {...actionIconProps} />
+                    </button>
+                    <button
+                      onClick={() => onDeleteReview(review.id, review.comment)}
+                      title="Delete review"
+                      className="p-1.5 text-gray-500 hover:text-error-600 dark:text-gray-400 dark:hover:text-error-400 rounded transition-colors"
+                    >
+                      <Trash2 {...actionIconProps} />
+                    </button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default ReviewTable;

--- a/src/components/page/SupervisionReviews/components/ReviewTablePagination.tsx
+++ b/src/components/page/SupervisionReviews/components/ReviewTablePagination.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import Pagination from "../../../tables/Pagination";
+import Select from "../../../form/Select";
+import {
+  SupervisionReviewFilters,
+  SupervisionReviewsResponse,
+} from "@/services/types/supervisionReview";
+
+interface ReviewTablePaginationProps {
+  data: SupervisionReviewsResponse | undefined;
+  filters: SupervisionReviewFilters;
+  onPageChange: (page: number) => void;
+  itemsPerPageOptions: { value: string; label: string }[];
+  onFilterChange: (key: keyof SupervisionReviewFilters, value: unknown) => void;
+}
+
+const ReviewTablePagination: React.FC<ReviewTablePaginationProps> = ({
+  data,
+  filters,
+  onPageChange,
+  itemsPerPageOptions,
+  onFilterChange,
+}) => {
+  if (!data?.success || !data?.data?.length || !data?.metaData) {
+    return null;
+  }
+
+  const { metaData } = data;
+  const limit = filters.limit || 10;
+
+  return (
+    <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-800">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          Showing {(metaData.page - 1) * limit + 1} to{" "}
+          {Math.min(metaData.page * limit, metaData.totalCount)} of{" "}
+          {metaData.totalCount} results
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+              Items per page:
+            </span>
+            <Select
+              value={limit.toString()}
+              onChange={(value: string) =>
+                onFilterChange("limit", parseInt(value))
+              }
+              options={itemsPerPageOptions}
+              className="w-auto min-w-[120px]"
+            />
+          </div>
+          <Pagination
+            currentPage={metaData.page}
+            totalPages={metaData.totalPages}
+            onPageChange={onPageChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReviewTablePagination;

--- a/src/components/page/SupervisionReviews/components/StarRating.tsx
+++ b/src/components/page/SupervisionReviews/components/StarRating.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface StarRatingProps {
+  rating: number;
+  max?: number;
+}
+
+const StarRating: React.FC<StarRatingProps> = ({ rating, max = 5 }) => {
+  return (
+    <div className="flex items-center gap-0.5">
+      {Array.from({ length: max }).map((_, i) => (
+        <svg
+          key={i}
+          className={`w-4 h-4 ${
+            i < rating
+              ? "text-yellow-400"
+              : "text-gray-300 dark:text-gray-600"
+          }`}
+          fill="currentColor"
+          viewBox="0 0 20 20"
+        >
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      ))}
+      <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
+        {rating}/{max}
+      </span>
+    </div>
+  );
+};
+
+export default StarRating;

--- a/src/components/page/SupervisionReviews/components/index.ts
+++ b/src/components/page/SupervisionReviews/components/index.ts
@@ -1,0 +1,5 @@
+export { default as ReviewHeader } from "./ReviewHeader";
+export { default as ReviewFilters } from "./ReviewFilters";
+export { default as ReviewTable } from "./ReviewTable";
+export { default as ReviewTablePagination } from "./ReviewTablePagination";
+export { default as StarRating } from "./StarRating";

--- a/src/components/page/SupervisionReviews/index.tsx
+++ b/src/components/page/SupervisionReviews/index.tsx
@@ -1,0 +1,115 @@
+"use client";
+import React from "react";
+import { BoltIcon } from "@/icons";
+import ErrorState from "../../common/ErrorState";
+import ConfirmationDialog from "../../ui/ConfirmationDialog";
+import { useSupervisionReviewsLogic } from "@/services/hooks/useSupervisionReviewsLogic";
+import {
+  ReviewHeader,
+  ReviewFilters,
+  ReviewTable,
+  ReviewTablePagination,
+} from "./components";
+
+const SupervisionReviews: React.FC = () => {
+  const {
+    filters,
+    searchInput,
+    setSearchInput,
+    applyKeywordSearch,
+    isFilterOpen,
+    setIsFilterOpen,
+    isPending,
+
+    data,
+    isLoading,
+    error,
+    refetch,
+
+    tableColumns,
+    ratingOptions,
+    itemsPerPageOptions,
+    filterChange,
+    initPageChange,
+    clearAllFilters,
+    clearIndividualFilter,
+    hasActiveFilters,
+    viewReview,
+
+    deleteConfirmReviewId,
+    deleteConfirmComment,
+    isDeleting,
+    openDeleteConfirm,
+    cancelDelete,
+    confirmDelete,
+  } = useSupervisionReviewsLogic();
+
+  if (error && !isPending) {
+    return (
+      <ErrorState
+        message={`Error loading reviews: ${error.message}`}
+        onRetry={() => refetch()}
+        retryIcon={<BoltIcon />}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+        <ReviewHeader
+          totalCount={data?.metaData?.totalCount || 0}
+          isPending={isPending}
+          isLoading={isLoading}
+          searchInput={searchInput}
+          setSearchInput={setSearchInput}
+          applyKeywordSearch={applyKeywordSearch}
+          isFilterOpen={isFilterOpen}
+          setIsFilterOpen={setIsFilterOpen}
+          onRefetch={refetch}
+          onClearFilters={clearAllFilters}
+          hasActiveFilters={hasActiveFilters}
+          filterDropdownContent={
+            <ReviewFilters
+              filters={filters}
+              onFilterChange={filterChange}
+              ratingOptions={ratingOptions}
+              hasActiveFilters={hasActiveFilters}
+              clearIndividualFilter={clearIndividualFilter}
+            />
+          }
+        />
+
+        <ReviewTable
+          data={data}
+          isLoading={isLoading}
+          tableColumns={tableColumns}
+          onViewReview={viewReview}
+          onDeleteReview={openDeleteConfirm}
+        />
+
+        <ReviewTablePagination
+          data={data}
+          filters={filters}
+          onPageChange={initPageChange}
+          itemsPerPageOptions={itemsPerPageOptions}
+          onFilterChange={filterChange}
+        />
+      </div>
+
+      <ConfirmationDialog
+        isOpen={!!deleteConfirmReviewId}
+        onClose={cancelDelete}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+        title="Delete Review"
+        message={`Are you sure you want to permanently delete this review? "${deleteConfirmComment}" This action cannot be undone.`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        isLoading={isDeleting}
+      />
+    </>
+  );
+};
+
+export default SupervisionReviews;

--- a/src/components/page/Supervisor/ViewDetails/index.tsx
+++ b/src/components/page/Supervisor/ViewDetails/index.tsx
@@ -274,10 +274,11 @@ export default function ViewDetails({ id }: ViewDetailsProps) {
               <SupervisorStatusBadge status={verificationStatus} />
             </div>
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{s.email}</p>
-            {s.occupation && (
+            {(profile?.supervisorType || s.supervisorOccupation) && (
               <p className="text-sm text-gray-600 dark:text-gray-300">
-                {s.occupation.name}
-                {s.specialty ? ` · ${s.specialty.name}` : ""}
+                {[profile?.supervisorType, s.supervisorOccupation, s.supervisorSpecialty]
+                  .filter(Boolean)
+                  .join(" · ")}
               </p>
             )}
             {location && <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{location}</p>}
@@ -301,8 +302,9 @@ export default function ViewDetails({ id }: ViewDetailsProps) {
 
           {/* Professional Info */}
           <SectionCard title="Professional Info">
-            <FieldRow label="Occupation" value={s.occupation?.name} />
-            <FieldRow label="Specialty" value={s.specialty?.name} />
+            <FieldRow label="Supervisor Type" value={profile?.supervisorType} />
+            <FieldRow label="Occupation" value={s.supervisorOccupation} />
+            <FieldRow label="Specialty" value={s.supervisorSpecialty} />
             <FieldRow label="Years of Experience" value={profile?.yearsOfExperience ? `${profile.yearsOfExperience} years` : null} />
             <FieldRow
               label="Professional Summary"

--- a/src/components/page/Supervisor/components/SupervisorTable.tsx
+++ b/src/components/page/Supervisor/components/SupervisorTable.tsx
@@ -99,16 +99,23 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                   )}
                 </TableCell>
 
+                {/* Supervisor Type */}
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                  {supervisor.supervisorType || (
+                    <span className="text-gray-400 italic">Not specified</span>
+                  )}
+                </TableCell>
+
                 {/* Occupation */}
                 <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
-                  {supervisor.occupation?.name || (
+                  {supervisor.supervisorOccupation || (
                     <span className="text-gray-400 italic">Not specified</span>
                   )}
                 </TableCell>
 
                 {/* Specialty */}
                 <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
-                  {supervisor.specialty?.name || (
+                  {supervisor.supervisorSpecialty || (
                     <span className="text-gray-400 italic">Not specified</span>
                   )}
                 </TableCell>

--- a/src/components/ui/ProfilePhotoUpload.tsx
+++ b/src/components/ui/ProfilePhotoUpload.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { useId, useRef } from "react";
+import { Pencil } from "lucide-react";
+import Avatar from "@/components/ui/avatar/Avatar";
+
+export interface ProfilePhotoUploadProps {
+  displayUrl?: string | null;
+  displayName?: string;
+  onFileSelect: (file: File) => void;
+  disabled?: boolean;
+  accept?: string;
+  /** Highlights the avatar when a new file is staged but not saved. */
+  hasPendingUpload?: boolean;
+  className?: string;
+}
+
+/** Click or hover the avatar to edit; file picker is hidden. */
+export function ProfilePhotoUpload({
+  displayUrl,
+  displayName = "User",
+  onFileSelect,
+  disabled = false,
+  accept = "image/jpeg,image/png,image/jpg",
+  hasPendingUpload = false,
+  className = "",
+}: ProfilePhotoUploadProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const openPicker = () => {
+    if (!disabled) inputRef.current?.click();
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onFileSelect(file);
+    e.target.value = "";
+  };
+
+  const hasPhoto = Boolean(displayUrl);
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={openPicker}
+        disabled={disabled}
+        aria-label={hasPhoto ? "Edit profile photo" : "Upload profile photo"}
+        className="group relative block rounded-full focus:outline-hidden focus-visible:ring-3 focus-visible:ring-brand-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <div
+          className={`relative h-24 w-24 overflow-hidden rounded-full border-2 bg-gray-50 dark:bg-gray-800 ${
+            hasPendingUpload
+              ? "border-brand-500 ring-2 ring-brand-500/20"
+              : "border-gray-200 dark:border-gray-600"
+          }`}
+        >
+          {hasPhoto ? (
+            // eslint-disable-next-line @next/next/no-img-element -- blob URLs are not compatible with next/image
+            <img src={displayUrl!} alt="Profile photo" className="h-full w-full object-cover" />
+          ) : (
+            <Avatar
+              src={undefined}
+              name={displayName}
+              size="xxlarge"
+              className="!h-full !w-full !max-w-none rounded-full border-0"
+            />
+          )}
+
+          <div
+            aria-hidden
+            className="absolute inset-0 flex items-center justify-center rounded-full bg-black/0 transition-colors group-hover:bg-black/45"
+          >
+            <Pencil className="h-6 w-6 text-white opacity-0 transition-opacity group-hover:opacity-100" />
+          </div>
+        </div>
+      </button>
+
+      <input
+        id={inputId}
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="sr-only"
+        disabled={disabled}
+        onChange={handleInputChange}
+      />
+    </div>
+  );
+}
+
+export default ProfilePhotoUpload;

--- a/src/components/ui/USPhoneInput.tsx
+++ b/src/components/ui/USPhoneInput.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+import Input from "@/components/ui/input/Input";
+import { formatUSPhoneForDisplay } from "@/services/utils/phoneNumberUtils";
+
+export interface USPhoneInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+  error?: boolean;
+  hint?: string;
+}
+
+/** US phone input with (XXX) XXX-XXXX formatting — aligned with Find Supervisor signup. */
+export function USPhoneInput({
+  value,
+  onChange,
+  onBlur,
+  disabled,
+  placeholder = "(555) 000-0000",
+  className,
+  error,
+  hint,
+}: USPhoneInputProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(formatUSPhoneForDisplay(e.target.value));
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pasted = e.clipboardData.getData("text");
+    if (pasted) {
+      e.preventDefault();
+      onChange(formatUSPhoneForDisplay(pasted));
+    }
+  };
+
+  return (
+    <Input
+      type="tel"
+      inputMode="numeric"
+      autoComplete="tel"
+      value={value}
+      onChange={handleChange}
+      onPaste={handlePaste}
+      onBlur={onBlur}
+      disabled={disabled}
+      placeholder={placeholder}
+      maxLength={14}
+      className={className}
+      error={error}
+      hint={hint}
+    />
+  );
+}
+
+export default USPhoneInput;

--- a/src/components/ui/form/FormField.tsx
+++ b/src/components/ui/form/FormField.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+import Label from "@/components/form/Label";
+
+export interface FormFieldProps {
+  label: React.ReactNode;
+  htmlFor?: string;
+  required?: boolean;
+  error?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/** Label, control, and inline validation message (matches `Input` hint styling). */
+export function FormField({
+  label,
+  htmlFor,
+  required,
+  error,
+  className = "",
+  children,
+}: FormFieldProps) {
+  return (
+    <div className={className}>
+      <Label htmlFor={htmlFor}>
+        {label}
+        {required ? <span className="text-error-500 ml-0.5">*</span> : null}
+      </Label>
+      {children}
+      {error ? (
+        <p className="mt-1.5 text-xs text-error-500 dark:text-error-400">{error}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export default FormField;

--- a/src/components/ui/form/index.ts
+++ b/src/components/ui/form/index.ts
@@ -1,0 +1,1 @@
+export { FormField, type FormFieldProps } from "./FormField";

--- a/src/context/PendingSupervisorContext.tsx
+++ b/src/context/PendingSupervisorContext.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React, { createContext, useContext, ReactNode } from "react";
+import { usePendingSupervisorCount } from "@/hooks/usePendingSupervisorCount";
+
+interface PendingSupervisorContextType {
+  pendingCount: number;
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+const PendingSupervisorContext = createContext<PendingSupervisorContextType | undefined>(undefined);
+
+export const usePendingSupervisorContext = () => {
+  const context = useContext(PendingSupervisorContext);
+  if (!context) {
+    throw new Error("usePendingSupervisorContext must be used within PendingSupervisorProvider");
+  }
+  return context;
+};
+
+interface PendingSupervisorProviderProps {
+  children: ReactNode;
+}
+
+export const PendingSupervisorProvider: React.FC<PendingSupervisorProviderProps> = ({ children }) => {
+  const { data, isLoading, refetch } = usePendingSupervisorCount();
+
+  const pendingCount = typeof data === "number" ? data : 0;
+
+  return (
+    <PendingSupervisorContext.Provider value={{ pendingCount, isLoading, refetch }}>
+      {children}
+    </PendingSupervisorContext.Provider>
+  );
+};

--- a/src/hooks/usePendingSupervisorCount.ts
+++ b/src/hooks/usePendingSupervisorCount.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { supervisorApi } from "@/services/api/supervisor";
+import { authUtils } from "@/services/utils/authUtils";
+
+export const usePendingSupervisorCount = () => {
+  const isAuthenticated = typeof window !== "undefined" ? authUtils.isAuthenticated() : false;
+
+  return useQuery({
+    queryKey: ["pending-supervisor-count"],
+    queryFn: async () => {
+      try {
+        const response = await supervisorApi.getSupervisors({
+          page: 1,
+          limit: 1,
+          verificationStatus: "PENDING",
+        });
+        return response?.metaData?.totalCount ?? 0;
+      } catch (error) {
+        console.error("[PendingSupervisorCount] Error fetching count:", error);
+        return 0;
+      }
+    },
+    enabled: isAuthenticated,
+    placeholderData: 0,
+    refetchInterval: 60000,
+    refetchOnWindowFocus: true,
+    staleTime: 30000,
+  });
+};

--- a/src/layout/PermissionAwareSidebar.tsx
+++ b/src/layout/PermissionAwareSidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { useSidebar } from "../context/SidebarContext";
 import { useAuthPermissions } from "../hooks/useAuthPermissions";
 import { useUnlockRequestContext } from "../context/UnlockRequestContext";
+import { usePendingSupervisorContext } from "../context/PendingSupervisorContext";
 import { hasAnyModulePermission, hasPermission } from "../utils/permissionUtils";
 import { authUtils } from "../services/utils/authUtils";
 import SidebarSkeleton from "../components/common/SidebarSkeleton";
@@ -47,6 +48,8 @@ type NavItem = {
     | "blog"
     // | "forum"
     | "unlockRequest";
+  /** Drives a pending-count badge independent of permissionKey */
+  badgeType?: "supervisors";
   isAccessible?: boolean;
 };
 
@@ -90,9 +93,14 @@ const navItems: NavItem[] = [
   },
   {
     icon: <IdCardIcon />,
-    name: "Supervisors",
+    name: "Find A Supervisor",
     path: "/admin/supervisors",
     isAccessible: true,
+    badgeType: "supervisors",
+    subItems: [
+      { name: "Supervisor", path: "/admin/supervisors" },
+      { name: "Supervisee", path: "/admin/supervisees" },
+    ],
   },
    {
     icon: <PieChartIcon />,
@@ -196,6 +204,14 @@ const AppSidebar: React.FC = () => {
   } catch (error) {
     // Context not available, use default value
     console.debug("[Sidebar] UnlockRequestContext not available");
+  }
+
+  let pendingSupervisorCount = 0;
+  try {
+    const supervisorContext = usePendingSupervisorContext();
+    pendingSupervisorCount = supervisorContext.pendingCount;
+  } catch (error) {
+    console.debug("[Sidebar] PendingSupervisorContext not available");
   }
 
   const pathname = usePathname();
@@ -310,29 +326,67 @@ const AppSidebar: React.FC = () => {
             {nav.subItems ? (
               <button
                 onClick={() => submenuToggle(index, menuType)}
-                className={`menu-item group  ${
+                className={`menu-item group relative ${
                   openSubmenu?.type === menuType && openSubmenu?.index === index
                     ? "menu-item-active"
                     : "menu-item-inactive"
-                } cursor-pointer ${!isExpanded && !isHovered ? "lg:justify-center" : "lg:justify-start"}`}
+                } cursor-pointer ${!isExpanded && !isHovered ? "lg:justify-center" : "lg:justify-start"} ${
+                  nav.badgeType === "supervisors" && pendingSupervisorCount > 0
+                    ? "!bg-[#006D36]/10 dark:!bg-[#006D36]/20 border-l-4 !border-[#006D36]"
+                    : ""
+                }`}
               >
                 <span
-                  className={` ${
+                  className={`${
                     openSubmenu?.type === menuType && openSubmenu?.index === index
                       ? "menu-item-icon-active"
                       : "menu-item-icon-inactive"
-                  }`}
+                  } ${nav.badgeType === "supervisors" && pendingSupervisorCount > 0 ? "!text-[#006D36]" : ""}`}
                 >
                   {nav.icon}
                 </span>
-                {(isExpanded || isHovered || isMobileOpen) && <span className={`menu-item-text`}>{nav.name}</span>}
                 {(isExpanded || isHovered || isMobileOpen) && (
-                  <ChevronDownIcon
-                    className={`ml-auto w-5 h-5 transition-transform duration-200  ${
-                      openSubmenu?.type === menuType && openSubmenu?.index === index ? "rotate-180 text-brand-500" : ""
+                  <span
+                    className={`menu-item-text ${
+                      nav.badgeType === "supervisors" && pendingSupervisorCount > 0 ? "!text-[#006D36] !font-semibold" : ""
                     }`}
-                  />
+                  >
+                    {nav.name}
+                  </span>
                 )}
+                {(isExpanded || isHovered || isMobileOpen) && (
+                  <span className="ml-auto flex items-center gap-1.5">
+                    {nav.badgeType === "supervisors" && pendingSupervisorCount > 0 && (
+                      <span className="relative group/badge">
+                        <span className="bg-[#006D36] text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[24px] text-center cursor-default">
+                          {pendingSupervisorCount}
+                        </span>
+                        <span className="pointer-events-none absolute bottom-full right-0 mb-2 hidden group-hover/badge:block bg-gray-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-50 shadow-lg">
+                          {pendingSupervisorCount} pending supervisor{pendingSupervisorCount !== 1 ? "s" : ""}
+                        </span>
+                      </span>
+                    )}
+                    <ChevronDownIcon
+                      className={`w-5 h-5 transition-transform duration-200 ${
+                        openSubmenu?.type === menuType && openSubmenu?.index === index ? "rotate-180 text-brand-500" : ""
+                      } ${nav.badgeType === "supervisors" && pendingSupervisorCount > 0 ? "!text-[#006D36]" : ""}`}
+                    />
+                  </span>
+                )}
+                {nav.badgeType === "supervisors" &&
+                  pendingSupervisorCount > 0 &&
+                  !isExpanded &&
+                  !isHovered &&
+                  !isMobileOpen && (
+                    <span className="absolute -top-1 -right-1 group/badge">
+                      <span className="bg-[#006D36] text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center cursor-default">
+                        {pendingSupervisorCount > 9 ? "9+" : pendingSupervisorCount}
+                      </span>
+                      <span className="pointer-events-none absolute bottom-full left-full ml-1 -translate-y-1/2 top-1/2 hidden group-hover/badge:block bg-gray-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-50 shadow-lg">
+                        {pendingSupervisorCount} pending supervisor{pendingSupervisorCount !== 1 ? "s" : ""}
+                      </span>
+                    </span>
+                  )}
               </button>
             ) : (
               nav.path && (
@@ -414,6 +468,11 @@ const AppSidebar: React.FC = () => {
 
                       // If we have permissions loaded but no specific permission requirement, show the item
                       if (permissions && !subItem.requiredAction) {
+                        return true;
+                      }
+
+                      // Always show subitems for explicitly accessible menu groups
+                      if (nav.isAccessible && !subItem.requiredAction) {
                         return true;
                       }
 

--- a/src/layout/PermissionAwareSidebar.tsx
+++ b/src/layout/PermissionAwareSidebar.tsx
@@ -36,6 +36,8 @@ type NavItem = {
     pro?: boolean;
     new?: boolean;
     requiredAction?: "view" | "add" | "edit" | "delete";
+    /** Drives a pending-count badge on this submenu item */
+    badgeType?: "supervisors";
   }[];
   permissionKey?:
     | "jobSeekers"
@@ -48,8 +50,6 @@ type NavItem = {
     | "blog"
     // | "forum"
     | "unlockRequest";
-  /** Drives a pending-count badge independent of permissionKey */
-  badgeType?: "supervisors";
   isAccessible?: boolean;
 };
 
@@ -96,10 +96,10 @@ const navItems: NavItem[] = [
     name: "Find A Supervisor",
     path: "/admin/supervisors",
     isAccessible: true,
-    badgeType: "supervisors",
     subItems: [
-      { name: "Supervisor", path: "/admin/supervisors" },
+      { name: "Supervisor", path: "/admin/supervisors", badgeType: "supervisors" },
       { name: "Supervisee", path: "/admin/supervisees" },
+      { name: "Reviews", path: "/admin/supervision-reviews" },
     ],
   },
    {
@@ -330,63 +330,27 @@ const AppSidebar: React.FC = () => {
                   openSubmenu?.type === menuType && openSubmenu?.index === index
                     ? "menu-item-active"
                     : "menu-item-inactive"
-                } cursor-pointer ${!isExpanded && !isHovered ? "lg:justify-center" : "lg:justify-start"} ${
-                  nav.badgeType === "supervisors" && pendingSupervisorCount > 0
-                    ? "!bg-[#006D36]/10 dark:!bg-[#006D36]/20 border-l-4 !border-[#006D36]"
-                    : ""
-                }`}
+                } cursor-pointer ${!isExpanded && !isHovered ? "lg:justify-center" : "lg:justify-start"}`}
               >
                 <span
                   className={`${
                     openSubmenu?.type === menuType && openSubmenu?.index === index
                       ? "menu-item-icon-active"
                       : "menu-item-icon-inactive"
-                  } ${nav.badgeType === "supervisors" && pendingSupervisorCount > 0 ? "!text-[#006D36]" : ""}`}
+                  }`}
                 >
                   {nav.icon}
                 </span>
                 {(isExpanded || isHovered || isMobileOpen) && (
-                  <span
-                    className={`menu-item-text ${
-                      nav.badgeType === "supervisors" && pendingSupervisorCount > 0 ? "!text-[#006D36] !font-semibold" : ""
-                    }`}
-                  >
-                    {nav.name}
-                  </span>
+                  <span className="menu-item-text">{nav.name}</span>
                 )}
                 {(isExpanded || isHovered || isMobileOpen) && (
-                  <span className="ml-auto flex items-center gap-1.5">
-                    {nav.badgeType === "supervisors" && pendingSupervisorCount > 0 && (
-                      <span className="relative group/badge">
-                        <span className="bg-[#006D36] text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[24px] text-center cursor-default">
-                          {pendingSupervisorCount}
-                        </span>
-                        <span className="pointer-events-none absolute bottom-full right-0 mb-2 hidden group-hover/badge:block bg-gray-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-50 shadow-lg">
-                          {pendingSupervisorCount} pending supervisor{pendingSupervisorCount !== 1 ? "s" : ""}
-                        </span>
-                      </span>
-                    )}
-                    <ChevronDownIcon
-                      className={`w-5 h-5 transition-transform duration-200 ${
-                        openSubmenu?.type === menuType && openSubmenu?.index === index ? "rotate-180 text-brand-500" : ""
-                      } ${nav.badgeType === "supervisors" && pendingSupervisorCount > 0 ? "!text-[#006D36]" : ""}`}
-                    />
-                  </span>
+                  <ChevronDownIcon
+                    className={`ml-auto w-5 h-5 transition-transform duration-200 ${
+                      openSubmenu?.type === menuType && openSubmenu?.index === index ? "rotate-180 text-brand-500" : ""
+                    }`}
+                  />
                 )}
-                {nav.badgeType === "supervisors" &&
-                  pendingSupervisorCount > 0 &&
-                  !isExpanded &&
-                  !isHovered &&
-                  !isMobileOpen && (
-                    <span className="absolute -top-1 -right-1 group/badge">
-                      <span className="bg-[#006D36] text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center cursor-default">
-                        {pendingSupervisorCount > 9 ? "9+" : pendingSupervisorCount}
-                      </span>
-                      <span className="pointer-events-none absolute bottom-full left-full ml-1 -translate-y-1/2 top-1/2 hidden group-hover/badge:block bg-gray-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-50 shadow-lg">
-                        {pendingSupervisorCount} pending supervisor{pendingSupervisorCount !== 1 ? "s" : ""}
-                      </span>
-                    </span>
-                  )}
               </button>
             ) : (
               nav.path && (
@@ -485,10 +449,24 @@ const AppSidebar: React.FC = () => {
                           href={subItem.path}
                           className={`menu-dropdown-item ${
                             isActive(subItem.path) ? "menu-dropdown-item-active" : "menu-dropdown-item-inactive"
+                          } ${
+                            subItem.badgeType === "supervisors" && pendingSupervisorCount > 0
+                              ? "!text-[#006D36] !font-semibold"
+                              : ""
                           }`}
                         >
                           {subItem.name}
                           <span className="flex items-center gap-1 ml-auto">
+                            {subItem.badgeType === "supervisors" && pendingSupervisorCount > 0 && (
+                              <span className="relative group/badge">
+                                <span className="bg-[#006D36] text-white text-xs font-bold rounded-full px-2 py-0.5 min-w-[24px] text-center cursor-default">
+                                  {pendingSupervisorCount > 9 ? "9+" : pendingSupervisorCount}
+                                </span>
+                                <span className="pointer-events-none absolute bottom-full right-0 mb-2 hidden group-hover/badge:block bg-gray-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-50 shadow-lg">
+                                  {pendingSupervisorCount} pending supervisor{pendingSupervisorCount !== 1 ? "s" : ""}
+                                </span>
+                              </span>
+                            )}
                             {subItem.new && (
                               <span
                                 className={`ml-auto ${
@@ -527,6 +505,7 @@ const AppSidebar: React.FC = () => {
   const [subMenuHeight, setSubMenuHeight] = useState<Record<string, number>>({});
   const subMenuRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const isActive = useCallback((path: string) => path === pathname, [pathname]);
+  const showSidebarSkeleton = loading && !permissions && isAuthenticated && hasUserData;
 
   useEffect(() => {
     let submenuMatched = false;
@@ -551,21 +530,36 @@ const AppSidebar: React.FC = () => {
     });
 
     if (!submenuMatched) {
+      if (pendingSupervisorCount > 0) {
+        const supervisorMenuIndex = navItems.findIndex((item) => item.name === "Find A Supervisor");
+        if (supervisorMenuIndex >= 0 && isItemAccessible(navItems[supervisorMenuIndex])) {
+          setOpenSubmenu({ type: "main", index: supervisorMenuIndex });
+          return;
+        }
+      }
       setOpenSubmenu(null);
     }
-  }, [pathname, isActive, permissions]);
+  }, [pathname, isActive, permissions, pendingSupervisorCount]);
 
   useEffect(() => {
-    if (openSubmenu !== null) {
-      const key = `${openSubmenu.type}-${openSubmenu.index}`;
-      if (subMenuRefs.current[key]) {
+    if (openSubmenu === null || showSidebarSkeleton) return;
+
+    const key = `${openSubmenu.type}-${openSubmenu.index}`;
+
+    const updateHeight = () => {
+      const el = subMenuRefs.current[key];
+      if (el) {
         setSubMenuHeight((prevHeights) => ({
           ...prevHeights,
-          [key]: subMenuRefs.current[key]?.scrollHeight || 0,
+          [key]: el.scrollHeight,
         }));
       }
-    }
-  }, [openSubmenu]);
+    };
+
+    updateHeight();
+    const frame = requestAnimationFrame(updateHeight);
+    return () => cancelAnimationFrame(frame);
+  }, [openSubmenu, showSidebarSkeleton, permissions, pendingSupervisorCount, isExpanded, isHovered, isMobileOpen]);
 
   const submenuToggle = (index: number, menuType: "main" | "others") => {
     setOpenSubmenu((prevOpenSubmenu) => {
@@ -577,7 +571,7 @@ const AppSidebar: React.FC = () => {
   };
 
   // Show skeleton if we're loading and don't have permissions yet, but only if authenticated
-  if (loading && !permissions && isAuthenticated && hasUserData) {
+  if (showSidebarSkeleton) {
     return (
       <aside
         className={`fixed flex flex-col lg:mt-0 top-0 px-5 left-0 bg-white dark:bg-gray-900 dark:border-gray-800 text-gray-900 h-screen transition-all duration-300 ease-in-out z-50 border-r border-gray-200 

--- a/src/services/api/supervisee.ts
+++ b/src/services/api/supervisee.ts
@@ -1,0 +1,44 @@
+import {
+  SuperviseeDetailsResponse,
+  SuperviseeFilters,
+  SuperviseeUpdatePayload,
+  SuperviseeUpdateResponse,
+  SuperviseesResponse,
+} from "../types/supervisee";
+import { apiGet, apiPatch } from "./apiUtils";
+import { buildSuperviseeUpdateFormData } from "../utils/superviseeProfileForm";
+import { showToast } from "../utils/toast";
+
+export const superviseeApi = {
+  async getSupervisees(filters: SuperviseeFilters = {}): Promise<SuperviseesResponse> {
+    try {
+      const queryParams = new URLSearchParams();
+
+      if (filters.page) queryParams.append("page", filters.page.toString());
+      if (filters.limit) queryParams.append("limit", filters.limit.toString());
+      if (filters.keyword) queryParams.append("keyword", filters.keyword);
+
+      const endpoint = `/api/supervision/admin/supervisees?${queryParams.toString()}`;
+      return apiGet<SuperviseesResponse>(endpoint);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      showToast.error("Supervisee Error", errorMessage);
+      throw error;
+    }
+  },
+
+  async getSuperviseeById(id: string): Promise<SuperviseeDetailsResponse> {
+    return apiGet<SuperviseeDetailsResponse>(`/api/supervision/admin/supervisees/${id}`);
+  },
+
+  async updateSupervisee(
+    id: string,
+    payload: SuperviseeUpdatePayload,
+  ): Promise<SuperviseeUpdateResponse> {
+    const formData = buildSuperviseeUpdateFormData(payload);
+    return apiPatch<SuperviseeUpdateResponse>(
+      `/api/supervision/admin/supervisees/${id}`,
+      formData,
+    );
+  },
+};

--- a/src/services/api/supervisionOptions.ts
+++ b/src/services/api/supervisionOptions.ts
@@ -12,7 +12,16 @@ export const SUPERVISION_PROFILE_OPTION_PARAMS = [
   "patientPopulation",
 ] as const;
 
-export type SupervisionProfileOptionsParam = (typeof SUPERVISION_PROFILE_OPTION_PARAMS)[number];
+export const SUPERVISION_SUPERVISEE_OPTION_PARAMS = [
+  "format",
+  "howSoon",
+  "availability",
+  "budgetType",
+] as const;
+
+export type SupervisionProfileOptionsParam =
+  | (typeof SUPERVISION_PROFILE_OPTION_PARAMS)[number]
+  | (typeof SUPERVISION_SUPERVISEE_OPTION_PARAMS)[number];
 
 type RawOption = string | { label: string; value: string };
 

--- a/src/services/api/supervisionReview.ts
+++ b/src/services/api/supervisionReview.ts
@@ -1,0 +1,50 @@
+import {
+  SupervisionReviewFilters,
+  SupervisionReviewsResponse,
+  SupervisionReviewDetailResponse,
+  SupervisionReviewDeleteResponse,
+} from "../types/supervisionReview";
+import { apiGet, apiDelete } from "./apiUtils";
+import { showToast } from "../utils/toast";
+
+export const supervisionReviewApi = {
+  async getReviews(
+    filters: SupervisionReviewFilters = {},
+  ): Promise<SupervisionReviewsResponse> {
+    try {
+      const queryParams = new URLSearchParams();
+
+      if (filters.page) queryParams.append("page", filters.page.toString());
+      if (filters.limit) queryParams.append("limit", filters.limit.toString());
+      if (filters.keyword) queryParams.append("keyword", filters.keyword);
+      if (filters.supervisorId)
+        queryParams.append("supervisorId", filters.supervisorId);
+      if (filters.superviseeId)
+        queryParams.append("superviseeId", filters.superviseeId);
+      if (filters.minRating)
+        queryParams.append("minRating", filters.minRating.toString());
+      if (filters.maxRating)
+        queryParams.append("maxRating", filters.maxRating.toString());
+
+      const endpoint = `/api/supervision/admin/reviews?${queryParams.toString()}`;
+      return apiGet<SupervisionReviewsResponse>(endpoint);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      showToast.error("Reviews Error", errorMessage);
+      throw error;
+    }
+  },
+
+  async getReviewById(id: string): Promise<SupervisionReviewDetailResponse> {
+    return apiGet<SupervisionReviewDetailResponse>(
+      `/api/supervision/admin/reviews/${id}`,
+    );
+  },
+
+  async deleteReview(id: string): Promise<SupervisionReviewDeleteResponse> {
+    return apiDelete<SupervisionReviewDeleteResponse>(
+      `/api/supervision/admin/reviews/${id}`,
+    );
+  },
+};

--- a/src/services/api/supervisorTypes.ts
+++ b/src/services/api/supervisorTypes.ts
@@ -1,0 +1,47 @@
+import { apiGet } from "./apiUtils";
+
+export interface SupervisionSelectOption {
+  label: string;
+  value: string;
+}
+
+export interface SupervisorSpecialtyData {
+  id: string;
+  occupationId: string;
+  name: string;
+}
+
+export interface SupervisorOccupationData {
+  id: string;
+  supervisorTypeId: string;
+  name: string;
+  specialties: SupervisorSpecialtyData[];
+}
+
+export interface SupervisorTypeData {
+  id: string;
+  code: string;
+  name: string;
+  occupations: SupervisorOccupationData[];
+}
+
+/** GET /api/supervision/supervisor-type — hierarchy for supervisee supervision needs. */
+export async function fetchSupervisorTypesData(): Promise<SupervisorTypeData[]> {
+  const res = await apiGet<{ success?: boolean; data?: SupervisorTypeData[] }>(
+    "/api/supervision/supervisor-type",
+  );
+  return Array.isArray(res?.data) ? res.data : [];
+}
+
+/** GET /api/categories/specialties/occupation/:id — profile specialty options. */
+export async function fetchSpecialtiesByOccupation(
+  occupationId: string,
+): Promise<SupervisionSelectOption[]> {
+  if (!occupationId) return [];
+  const body = await apiGet<{
+    success?: boolean;
+    data?: { specialty: { id: number; name: string }[] };
+  }>(`/api/categories/specialties/occupation/${occupationId}`);
+  const list = body?.data?.specialty ?? [];
+  return list.map((s) => ({ label: s.name, value: String(s.id) }));
+}

--- a/src/services/hooks/useSuperviseeLogic.ts
+++ b/src/services/hooks/useSuperviseeLogic.ts
@@ -1,0 +1,240 @@
+import { useState, useMemo, useTransition, useEffect, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSupervisees } from "@/services/hooks/useSupervisees";
+import { SuperviseeFilters } from "@/services/types/supervisee";
+
+export const useSuperviseeLogic = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const getInitialFilters = (): SuperviseeFilters => {
+    const hasUrlParams = Array.from(searchParams.keys()).length > 0;
+
+    if (hasUrlParams) {
+      const keyword = searchParams.get("keyword") || "";
+      const urlPage = searchParams.get("page");
+
+      const urlFilters: SuperviseeFilters = {
+        page: Math.max(1, parseInt(urlPage || "1", 10)),
+        limit: parseInt(searchParams.get("limit") || "10", 10),
+        keyword,
+      };
+
+      const isSimpleNavigation = (!urlPage || urlPage === "1") && !keyword;
+
+      if (isSimpleNavigation && typeof window !== "undefined") {
+        localStorage.removeItem("supervisee-search-state");
+        localStorage.removeItem("supervisee-scroll-position");
+      }
+
+      return urlFilters;
+    }
+
+    if (typeof window !== "undefined") {
+      const navigationFlag = sessionStorage.getItem("supervisee-preserve-state");
+
+      if (navigationFlag === "true") {
+        sessionStorage.removeItem("supervisee-preserve-state");
+
+        const savedState = localStorage.getItem("supervisee-search-state");
+        if (savedState) {
+          try {
+            const parsed = JSON.parse(savedState);
+            return {
+              page: Math.max(1, parsed.page || 1),
+              limit: parsed.limit || 10,
+              keyword: parsed.keyword || "",
+            };
+          } catch {
+            // fall through
+          }
+        }
+      } else {
+        localStorage.removeItem("supervisee-search-state");
+        localStorage.removeItem("supervisee-scroll-position");
+      }
+    }
+
+    return { page: 1, limit: 10, keyword: "" };
+  };
+
+  const initialFilters = getInitialFilters();
+  const [filters, setFilters] = useState<SuperviseeFilters>(() => initialFilters);
+  const [searchInput, setSearchInput] = useState(() => initialFilters.keyword || "");
+  const [isPending, startTransition] = useTransition();
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [hasRestoredFromState, setHasRestoredFromState] = useState(false);
+
+  const [editModal, setEditModal] = useState<{
+    isOpen: boolean;
+    superviseeId: string;
+    fullName: string;
+  }>({ isOpen: false, superviseeId: "", fullName: "" });
+
+  useEffect(() => {
+    setIsInitialized(true);
+    if (initialFilters.keyword || (initialFilters.page && initialFilters.page > 1)) {
+      setHasRestoredFromState(true);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+
+    if (filters.page && filters.page > 1) params.set("page", filters.page.toString());
+    if (filters.limit && filters.limit !== 10) params.set("limit", filters.limit.toString());
+    if (filters.keyword) params.set("keyword", encodeURIComponent(filters.keyword));
+
+    const newURL = params.toString() ? `?${params.toString()}` : "";
+    const currentURL = window.location.search;
+
+    if (newURL !== currentURL) {
+      router.replace(`/admin/supervisees${newURL}`, { scroll: false });
+    }
+  }, [filters, router]);
+
+  useEffect(() => {
+    const hasUrlParams = Array.from(searchParams.keys()).length > 0;
+    if (!hasUrlParams && typeof window !== "undefined") {
+      const savedPosition = localStorage.getItem("supervisee-scroll-position");
+      if (savedPosition) {
+        const position = parseInt(savedPosition, 10);
+        setTimeout(() => window.scrollTo({ top: position, behavior: "smooth" }), 100);
+      }
+    }
+  }, [searchParams]);
+
+  const saveScrollPosition = useCallback(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("supervisee-scroll-position", window.scrollY.toString());
+    }
+  }, []);
+
+  const saveSearchState = useCallback(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(
+        "supervisee-search-state",
+        JSON.stringify({
+          page: filters.page,
+          limit: filters.limit,
+          keyword: filters.keyword,
+        }),
+      );
+    }
+  }, [filters]);
+
+  const { data, isLoading, error, refetch } = useSupervisees(filters);
+
+  const tableColumns = useMemo(
+    () => [
+      { key: "name", label: "Name" },
+      { key: "email", label: "Email" },
+      { key: "state", label: "State" },
+      { key: "format", label: "Preferred Format" },
+      { key: "howSoon", label: "How Soon" },
+      { key: "emailVerified", label: "Email" },
+      { key: "createdAt", label: "Registered" },
+      { key: "actions", label: "", className: "text-right" },
+    ],
+    [],
+  );
+
+  const itemsPerPageOptions = useMemo(
+    () => [
+      { value: "10", label: "10 per page" },
+      { value: "20", label: "20 per page" },
+      { value: "50", label: "50 per page" },
+      { value: "100", label: "100 per page" },
+    ],
+    [],
+  );
+
+  const filterChange = useCallback((key: keyof SuperviseeFilters, value: any) => {
+    startTransition(() => {
+      setFilters((prev) => ({
+        ...prev,
+        [key]: value === "" ? undefined : value,
+        page: 1,
+      }));
+    });
+  }, []);
+
+  const initPageChange = useCallback((newPage: number) => {
+    setFilters((prev) => ({ ...prev, page: newPage }));
+  }, []);
+
+  const viewSupervisee = useCallback(
+    (superviseeId: string) => {
+      saveScrollPosition();
+      saveSearchState();
+
+      if (typeof window !== "undefined") {
+        sessionStorage.setItem("supervisee-preserve-state", "true");
+        sessionStorage.setItem("supervisee-selected-item", superviseeId);
+      }
+
+      router.push(`/admin/supervisees/details/${superviseeId}`);
+    },
+    [router, saveScrollPosition, saveSearchState],
+  );
+
+  const openEditModal = useCallback((superviseeId: string, fullName: string) => {
+    setEditModal({ isOpen: true, superviseeId, fullName });
+  }, []);
+
+  const closeEditModal = useCallback(() => {
+    setEditModal({ isOpen: false, superviseeId: "", fullName: "" });
+  }, []);
+
+  const clearAllFilters = useCallback(() => {
+    setFilters({ page: 1, limit: 10, keyword: "" });
+    setSearchInput("");
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("supervisee-scroll-position");
+      localStorage.removeItem("supervisee-search-state");
+    }
+  }, []);
+
+  const hasActiveFilters = useMemo(() => !!searchInput, [searchInput]);
+
+  useEffect(() => {
+    if (!isInitialized) return;
+    if (hasRestoredFromState && searchInput === initialFilters.keyword) return;
+
+    const timeoutId = setTimeout(() => {
+      startTransition(() => {
+        const shouldResetPage = searchInput !== filters.keyword;
+        setFilters((prev) => ({
+          ...prev,
+          keyword: searchInput,
+          page: shouldResetPage ? 1 : prev.page,
+        }));
+
+        if (hasRestoredFromState) setHasRestoredFromState(false);
+      });
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [searchInput, isInitialized, filters.keyword, hasRestoredFromState, initialFilters.keyword]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    filters,
+    searchInput,
+    setSearchInput,
+    isPending,
+    data,
+    isLoading,
+    error,
+    refetch,
+    tableColumns,
+    itemsPerPageOptions,
+    filterChange,
+    initPageChange,
+    viewSupervisee,
+    clearAllFilters,
+    hasActiveFilters,
+    editModal,
+    openEditModal,
+    closeEditModal,
+  };
+};

--- a/src/services/hooks/useSupervisees.ts
+++ b/src/services/hooks/useSupervisees.ts
@@ -1,0 +1,116 @@
+import { useQuery, useMutation, useQueryClient, useQueries } from "@tanstack/react-query";
+import { superviseeApi } from "../api/supervisee";
+import {
+  fetchSupervisionOptions,
+  SUPERVISION_SUPERVISEE_OPTION_PARAMS,
+  type SupervisionProfileOptionsParam,
+} from "../api/supervisionOptions";
+import {
+  fetchSpecialtiesByOccupation,
+  fetchSupervisorTypesData,
+} from "../api/supervisorTypes";
+import type { SuperviseeFilters } from "../types/supervisee";
+import { showToast } from "../utils/toast";
+
+export type SuperviseeFormOptionsParam = (typeof SUPERVISION_SUPERVISEE_OPTION_PARAMS)[number];
+
+export const superviseeQueryKeys = {
+  all: ["supervisees"] as const,
+  lists: () => [...superviseeQueryKeys.all, "list"] as const,
+  list: (filters: SuperviseeFilters) => [...superviseeQueryKeys.lists(), filters] as const,
+  details: () => [...superviseeQueryKeys.all, "detail"] as const,
+  detail: (id: string) => [...superviseeQueryKeys.details(), id] as const,
+};
+
+export const superviseeFormOptionsQueryKeys = {
+  byParam: (param: SuperviseeFormOptionsParam) => ["supervisee", "form-options", param] as const,
+};
+
+export const supervisorTypesQueryKey = ["supervisor-types-data"] as const;
+
+export const useSupervisees = (filters: SuperviseeFilters = {}) => {
+  return useQuery({
+    queryKey: superviseeQueryKeys.list(filters),
+    queryFn: () => superviseeApi.getSupervisees(filters),
+    staleTime: 1000 * 60 * 5,
+    retry: (failureCount, error: Error) => {
+      if (error.message.includes("HTTP 401")) return false;
+      return failureCount < 3;
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+};
+
+export const useSuperviseeDetails = (id: string) => {
+  return useQuery({
+    queryKey: superviseeQueryKeys.detail(id),
+    queryFn: () => superviseeApi.getSuperviseeById(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5,
+    retry: (failureCount, error: Error) => {
+      if (error.message.includes("HTTP 401")) return false;
+      return failureCount < 3;
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+};
+
+export const useSupervisorTypesData = () => {
+  return useQuery({
+    queryKey: supervisorTypesQueryKey,
+    queryFn: fetchSupervisorTypesData,
+    staleTime: 1000 * 60 * 10,
+  });
+};
+
+export const useSpecialtiesByOccupation = (occupationId: string) => {
+  return useQuery({
+    queryKey: ["supervisee", "profile-specialty", occupationId],
+    queryFn: () => fetchSpecialtiesByOccupation(occupationId),
+    enabled: occupationId.length > 0,
+    staleTime: 1000 * 60 * 10,
+  });
+};
+
+export const useSuperviseeFormOptions = () => {
+  const queries = useQueries({
+    queries: SUPERVISION_SUPERVISEE_OPTION_PARAMS.map((param) => ({
+      queryKey: superviseeFormOptionsQueryKeys.byParam(param),
+      queryFn: () => fetchSupervisionOptions(param as SupervisionProfileOptionsParam),
+      staleTime: 1000 * 60 * 10,
+    })),
+  });
+
+  return {
+    formatOptions: queries[0].data ?? [],
+    howSoonOptions: queries[1].data ?? [],
+    availabilityOptions: queries[2].data ?? [],
+    budgetTypeOptions: queries[3].data ?? [],
+    isLoading: queries.some((q) => q.isLoading),
+  };
+};
+
+export const useUpdateSupervisee = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: Parameters<typeof superviseeApi.updateSupervisee>[1];
+    }) => superviseeApi.updateSupervisee(id, payload),
+    onSuccess: async (_response, { id }) => {
+      showToast.success("Supervisee Updated", "Profile changes were saved successfully.");
+      await queryClient.invalidateQueries({ queryKey: superviseeQueryKeys.lists() });
+      await queryClient.invalidateQueries({ queryKey: superviseeQueryKeys.detail(id) });
+    },
+    onError: (error: Error) => {
+      showToast.error(
+        "Update Failed",
+        error.message || "Failed to update supervisee. Please try again.",
+      );
+    },
+  });
+};

--- a/src/services/hooks/useSupervisionReviews.ts
+++ b/src/services/hooks/useSupervisionReviews.ts
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supervisionReviewApi } from "../api/supervisionReview";
+import { SupervisionReviewFilters } from "../types/supervisionReview";
+import { showToast } from "../utils/toast";
+
+export const supervisionReviewQueryKeys = {
+  all: ["supervisionReviews"] as const,
+  lists: () => [...supervisionReviewQueryKeys.all, "list"] as const,
+  list: (filters: SupervisionReviewFilters) =>
+    [...supervisionReviewQueryKeys.lists(), filters] as const,
+  details: () => [...supervisionReviewQueryKeys.all, "detail"] as const,
+  detail: (id: string) => [...supervisionReviewQueryKeys.details(), id] as const,
+};
+
+export const useSupervisionReviews = (
+  filters: SupervisionReviewFilters = {},
+) => {
+  return useQuery({
+    queryKey: supervisionReviewQueryKeys.list(filters),
+    queryFn: () => supervisionReviewApi.getReviews(filters),
+    staleTime: 1000 * 60 * 5,
+    retry: (failureCount, error: Error) => {
+      if (error.message.includes("HTTP 401")) return false;
+      return failureCount < 3;
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+};
+
+export const useSupervisionReviewDetails = (id: string) => {
+  return useQuery({
+    queryKey: supervisionReviewQueryKeys.detail(id),
+    queryFn: () => supervisionReviewApi.getReviewById(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5,
+    retry: (failureCount, error: Error) => {
+      if (error.message.includes("HTTP 401")) return false;
+      return failureCount < 3;
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+};
+
+export const useDeleteSupervisionReview = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => supervisionReviewApi.deleteReview(id),
+    onSuccess: () => {
+      showToast.success(
+        "Review Deleted",
+        "The review has been removed successfully.",
+      );
+      queryClient.invalidateQueries({
+        queryKey: supervisionReviewQueryKeys.lists(),
+      });
+    },
+    onError: (error: Error) => {
+      showToast.error(
+        "Delete Failed",
+        error.message || "Failed to delete review. Please try again.",
+      );
+    },
+  });
+};

--- a/src/services/hooks/useSupervisionReviewsLogic.ts
+++ b/src/services/hooks/useSupervisionReviewsLogic.ts
@@ -1,0 +1,199 @@
+import { useState, useMemo, useTransition, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  useSupervisionReviews,
+  useDeleteSupervisionReview,
+} from "@/services/hooks/useSupervisionReviews";
+import { SupervisionReviewFilters } from "@/services/types/supervisionReview";
+
+export const useSupervisionReviewsLogic = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const getInitialFilters = (): SupervisionReviewFilters => {
+    const keyword = searchParams.get("keyword") || "";
+    const urlPage = searchParams.get("page");
+    const minRating = searchParams.get("minRating");
+    const maxRating = searchParams.get("maxRating");
+
+    return {
+      page: Math.max(1, parseInt(urlPage || "1", 10)),
+      limit: parseInt(searchParams.get("limit") || "10", 10),
+      keyword,
+      minRating: minRating ? parseInt(minRating, 10) : undefined,
+      maxRating: maxRating ? parseInt(maxRating, 10) : undefined,
+    };
+  };
+
+  const initialFilters = getInitialFilters();
+  const [filters, setFilters] = useState<SupervisionReviewFilters>(
+    () => initialFilters,
+  );
+  const [searchInput, setSearchInput] = useState(
+    () => initialFilters.keyword || "",
+  );
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  // Delete confirm state
+  const [deleteConfirmReviewId, setDeleteConfirmReviewId] = useState<
+    string | null
+  >(null);
+  const [deleteConfirmComment, setDeleteConfirmComment] = useState<string>("");
+
+  const { mutateAsync: deleteMutation, isPending: isDeleting } =
+    useDeleteSupervisionReview();
+
+  // Sync keyword input with debounce via useEffect in the component (standard pattern)
+  const applyKeywordSearch = useCallback((value: string) => {
+    startTransition(() => {
+      setFilters((prev) => ({
+        ...prev,
+        keyword: value || undefined,
+        page: 1,
+      }));
+    });
+  }, []);
+
+  const filterChange = useCallback(
+    (key: keyof SupervisionReviewFilters, value: unknown) => {
+      startTransition(() => {
+        setFilters((prev) => ({
+          ...prev,
+          [key]: value === "" || value === 0 ? undefined : value,
+          page: 1,
+        }));
+      });
+    },
+    [],
+  );
+
+  const initPageChange = useCallback((newPage: number) => {
+    setFilters((prev) => ({ ...prev, page: newPage }));
+  }, []);
+
+  const clearAllFilters = useCallback(() => {
+    setSearchInput("");
+    startTransition(() => {
+      setFilters({ page: 1, limit: filters.limit || 10 });
+    });
+  }, [filters.limit]);
+
+  const clearIndividualFilter = useCallback(
+    (key: keyof SupervisionReviewFilters) => {
+      if (key === "keyword") setSearchInput("");
+      startTransition(() => {
+        setFilters((prev) => ({ ...prev, [key]: undefined, page: 1 }));
+      });
+    },
+    [],
+  );
+
+  const hasActiveFilters = useMemo(
+    () =>
+      !!(
+        filters.keyword ||
+        filters.minRating ||
+        filters.maxRating ||
+        filters.supervisorId ||
+        filters.superviseeId
+      ),
+    [filters],
+  );
+
+  // Delete handlers
+  const openDeleteConfirm = useCallback(
+    (reviewId: string, comment: string | null) => {
+      setDeleteConfirmReviewId(reviewId);
+      setDeleteConfirmComment(comment ? comment.slice(0, 80) : "No comment");
+    },
+    [],
+  );
+
+  const cancelDelete = useCallback(() => {
+    setDeleteConfirmReviewId(null);
+    setDeleteConfirmComment("");
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteConfirmReviewId) return;
+    await deleteMutation(deleteConfirmReviewId);
+    setDeleteConfirmReviewId(null);
+    setDeleteConfirmComment("");
+  }, [deleteConfirmReviewId, deleteMutation]);
+
+  const viewReview = useCallback(
+    (reviewId: string) => {
+      router.push(`/admin/supervision-reviews/details/${reviewId}`);
+    },
+    [router],
+  );
+
+  const { data, isLoading, error, refetch } = useSupervisionReviews(filters);
+
+  const tableColumns = useMemo(
+    () => [
+      { key: "supervisee", label: "Supervisee" },
+      { key: "supervisor", label: "Supervisor" },
+      { key: "rating", label: "Rating" },
+      { key: "comment", label: "Comment" },
+      { key: "hire", label: "Hire Status" },
+      { key: "createdAt", label: "Submitted" },
+      { key: "actions", label: "", className: "text-right" },
+    ],
+    [],
+  );
+
+  const ratingOptions = useMemo(
+    () => [
+      { value: "1", label: "1 star" },
+      { value: "2", label: "2 stars" },
+      { value: "3", label: "3 stars" },
+      { value: "4", label: "4 stars" },
+      { value: "5", label: "5 stars" },
+    ],
+    [],
+  );
+
+  const itemsPerPageOptions = useMemo(
+    () => [
+      { value: "10", label: "10 per page" },
+      { value: "20", label: "20 per page" },
+      { value: "50", label: "50 per page" },
+      { value: "100", label: "100 per page" },
+    ],
+    [],
+  );
+
+  return {
+    filters,
+    searchInput,
+    setSearchInput,
+    applyKeywordSearch,
+    isFilterOpen,
+    setIsFilterOpen,
+    isPending,
+
+    data,
+    isLoading,
+    error,
+    refetch,
+
+    tableColumns,
+    ratingOptions,
+    itemsPerPageOptions,
+    filterChange,
+    initPageChange,
+    clearAllFilters,
+    clearIndividualFilter,
+    hasActiveFilters,
+    viewReview,
+
+    deleteConfirmReviewId,
+    deleteConfirmComment,
+    isDeleting,
+    openDeleteConfirm,
+    cancelDelete,
+    confirmDelete,
+  };
+};

--- a/src/services/hooks/useSupervisorLogic.ts
+++ b/src/services/hooks/useSupervisorLogic.ts
@@ -154,6 +154,7 @@ export const useSupervisorLogic = () => {
       { key: "name", label: "Name" },
       { key: "email", label: "Email" },
       { key: "state", label: "State" },
+      { key: "supervisorType", label: "Supervisor Type" },
       { key: "occupation", label: "Occupation" },
       { key: "specialty", label: "Specialty" },
       { key: "licenseType", label: "License Type" },

--- a/src/services/types/SuperviseeTypes.ts
+++ b/src/services/types/SuperviseeTypes.ts
@@ -1,0 +1,28 @@
+import { SuperviseeFilters, SuperviseesResponse } from "@/services/types/supervisee";
+
+export interface SuperviseesProps {
+  className?: string;
+}
+
+export interface SuperviseeHeaderProps {
+  totalCount: number;
+  isPending: boolean;
+  searchInput: string;
+  setSearchInput: (value: string) => void;
+}
+
+export interface SuperviseeTableProps {
+  data: SuperviseesResponse | undefined;
+  isLoading: boolean;
+  tableColumns: Array<{ key: string; label: string; className?: string }>;
+  onViewSupervisee: (superviseeId: string) => void;
+  onEditSupervisee: (superviseeId: string, fullName: string) => void;
+}
+
+export interface SuperviseeTablePaginationProps {
+  data: SuperviseesResponse | undefined;
+  filters: SuperviseeFilters;
+  onPageChange: (page: number) => void;
+  itemsPerPageOptions: Array<{ value: string; label: string }>;
+  onFilterChange: (key: keyof SuperviseeFilters, value: any) => void;
+}

--- a/src/services/types/supervisee.ts
+++ b/src/services/types/supervisee.ts
@@ -1,0 +1,164 @@
+export interface SuperviseeOccupation {
+  id: number;
+  name: string;
+}
+
+export interface SuperviseeSpecialty {
+  id: number;
+  name: string;
+}
+
+/** Shape returned by GET /api/supervision/admin/supervisees list items */
+export interface Supervisee {
+  id: string;
+  fullName: string;
+  email: string;
+  state: string | null;
+  contactNumber: string | null;
+  profilePhotoUrl: string | null;
+  emailVerified: boolean;
+  isActive: boolean;
+  status: string;
+  occupation: SuperviseeOccupation | null;
+  specialty: SuperviseeSpecialty | null;
+  preferredFormat: string | null;
+  howSoonLooking: string | null;
+  stateTheyAreLookingIn: string[];
+  budgetRangeType: string | null;
+  budgetRangeStart: number | null;
+  budgetRangeEnd: number | null;
+  superviseeOccupation: string | null;
+  superviseeSpecialty: string | null;
+  createdAt: string;
+}
+
+export interface SuperviseeFilters {
+  page?: number;
+  limit?: number;
+  keyword?: string;
+}
+
+export interface SuperviseesMetaData {
+  page: number;
+  limit: number;
+  totalPages: number;
+  totalCount: number;
+  currentPageTotalItems: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface SuperviseesResponse {
+  success: boolean;
+  data: Supervisee[];
+  metaData: SuperviseesMetaData;
+  message?: string;
+}
+
+export interface SuperviseeProfile {
+  id: string;
+  userId: string;
+  typeOfSupervisorNeeded: string[];
+  howSoonLooking: string | null;
+  lookingDate: string | null;
+  preferredFormat: string | null;
+  title: string | null;
+  superviseeOccupation: string | null;
+  superviseeSpecialty: string | null;
+  availability: string | null;
+  idealSupervisor: string | null;
+  stateTheyAreLookingIn: string[];
+  budgetRangeType: string | null;
+  budgetRangeStart: number | null;
+  budgetRangeEnd: number | null;
+  completedCount: number;
+  leftCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SuperviseeSubscriptionPlan {
+  id: string;
+  name: string;
+  description: string | null;
+  priceInCents: number;
+  billingCycle: string;
+  isActive: boolean;
+}
+
+export interface SuperviseeSubscription {
+  id: string;
+  status: string;
+  currentPeriodStart: string | null;
+  currentPeriodEnd: string | null;
+  createdAt: string;
+  plan: SuperviseeSubscriptionPlan;
+}
+
+/** Full detail shape from GET /api/supervision/admin/supervisees/:id */
+export interface SuperviseeDetails {
+  id: string;
+  email: string;
+  userName: string;
+  fullName: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  contactNumber: string | null;
+  city: string | null;
+  state: string | null;
+  zipcode: string | null;
+  profilePhotoUrl: string | null;
+  stateOfLicensure: string[];
+  emailVerified: boolean;
+  emailVerifiedAt: string | null;
+  isActive: boolean;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  occupation: SuperviseeOccupation | null;
+  specialty: SuperviseeSpecialty | null;
+  occupationId?: number | null;
+  specialtyId?: number | null;
+  superviseeProfile: SuperviseeProfile | null;
+  subscriptions: SuperviseeSubscription[];
+}
+
+export interface SuperviseeDetailsResponse {
+  success: boolean;
+  data: SuperviseeDetails;
+  message?: string;
+}
+
+export interface SuperviseeUpdatePayload {
+  fullName?: string;
+  contactNumber?: string;
+  city?: string;
+  state?: string;
+  zipcode?: string;
+  occupation?: string;
+  specialty?: string;
+  title?: string;
+  stateOfLicensure?: string[];
+  typeOfSupervisorNeeded?: string[];
+  superviseeOccupation?: string;
+  superviseeSpecialty?: string;
+  howSoonLooking?: string;
+  lookingDate?: string;
+  preferredFormat?: string;
+  availability?: string;
+  idealSupervisor?: string;
+  stateTheyAreLookingIn?: string[];
+  budgetRangeType?: string;
+  budgetRangeStart?: number;
+  budgetRangeEnd?: number;
+  uploadProfilePhoto?: File;
+}
+
+export interface SuperviseeUpdateResponse {
+  success: boolean;
+  message: string;
+  data: {
+    user: SuperviseeDetails;
+    supervisee: SuperviseeProfile;
+  };
+}

--- a/src/services/types/supervisionReview.ts
+++ b/src/services/types/supervisionReview.ts
@@ -1,0 +1,76 @@
+export interface ReviewSupervisor {
+  id: string;
+  fullName: string | null;
+  email: string;
+  profilePhotoUrl: string | null;
+}
+
+export interface ReviewSupervisee {
+  id: string;
+  fullName: string | null;
+  email: string;
+  profilePhotoUrl: string | null;
+  city: string | null;
+  state: string | null;
+  occupation: { id: number; name: string } | null;
+}
+
+export interface ReviewHire {
+  id: string;
+  status: string;
+  startDate: string | null;
+  endDate: string | null;
+  createdAt: string;
+}
+
+export interface SupervisionReview {
+  id: string;
+  rating: number;
+  comment: string | null;
+  createdAt: string;
+  updatedAt: string;
+  supervisorId: string;
+  superviseeId: string;
+  hireId: string | null;
+  supervisor: ReviewSupervisor;
+  supervisee: ReviewSupervisee;
+  hire: ReviewHire | null;
+}
+
+export interface SupervisionReviewFilters {
+  page?: number;
+  limit?: number;
+  keyword?: string;
+  supervisorId?: string;
+  superviseeId?: string;
+  minRating?: number;
+  maxRating?: number;
+}
+
+export interface SupervisionReviewsMetaData {
+  page: number;
+  limit: number;
+  totalPages: number;
+  totalCount: number;
+  currentPageTotalItems: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+export interface SupervisionReviewsResponse {
+  success: boolean;
+  data: SupervisionReview[];
+  metaData: SupervisionReviewsMetaData;
+  message?: string;
+}
+
+export interface SupervisionReviewDetailResponse {
+  success: boolean;
+  data: SupervisionReview;
+  message?: string;
+}
+
+export interface SupervisionReviewDeleteResponse {
+  success: boolean;
+  message: string;
+}

--- a/src/services/types/supervisor.ts
+++ b/src/services/types/supervisor.ts
@@ -20,6 +20,10 @@ export interface Supervisor {
   profilePhotoUrl: string | null;
   occupation: SupervisorOccupation | null;
   specialty: SupervisorSpecialty | null;
+  /** Hierarchy-based plain strings from SupervisorProfile */
+  supervisorType: string | null;
+  supervisorOccupation: string | null;
+  supervisorSpecialty: string | null;
   verificationStatus: VerificationStatus;
   licenseType: string | null;
   yearsOfExperience: string | null;
@@ -75,6 +79,10 @@ export interface SupervisorProfile {
   supervisionFeeAmount: number | null;
   professionalSummary: string | null;
   website: string | null;
+  /** Hierarchy-based plain strings */
+  supervisorType: string | null;
+  occupation: string | null;
+  specialty: string | null;
   verificationStatus: VerificationStatus;
   verificationNotes: string | null;
   verificationNotesAt: string | null;
@@ -128,8 +136,12 @@ export interface SupervisorDetails {
   status: string;
   createdAt: string;
   updatedAt: string;
+  /** Legacy FK-based objects from SupervisionUser (may be null for new registrations) */
   occupation: SupervisorOccupation | null;
   specialty: SupervisorSpecialty | null;
+  /** Hierarchy-based plain strings lifted from SupervisorProfile */
+  supervisorOccupation: string | null;
+  supervisorSpecialty: string | null;
   supervisorProfile: SupervisorProfile | null;
   /** supervisorSettings and permissions are excluded until the DB migration is applied */
   subscriptions: SupervisorSubscription[];

--- a/src/services/utils/phoneNumberUtils.ts
+++ b/src/services/utils/phoneNumberUtils.ts
@@ -3,6 +3,29 @@ export const formatPhoneNumber = (phoneNumber: string) => {
 };
 
 /** US NANP display without country prefix, e.g. (423) 123-4567 */
+const US_LOCAL_DIGITS = 10;
+
+/** Formats raw input for tel fields as (XXX) XXX-XXXX — matches Find Supervisor signup. */
+export function formatUSPhoneForDisplay(input: string): string {
+  const digits = input.replace(/\D/g, "");
+  if (digits.length === 0) return "";
+
+  let toFormat = digits;
+  if (digits.startsWith("1") && digits.length > US_LOCAL_DIGITS) {
+    toFormat = digits.slice(1, US_LOCAL_DIGITS + 1);
+  } else if (digits.length > US_LOCAL_DIGITS) {
+    toFormat = digits.slice(0, US_LOCAL_DIGITS);
+  }
+
+  if (toFormat.length <= 3) {
+    return toFormat.length > 0 ? `(${toFormat}` : "";
+  }
+  if (toFormat.length <= 6) {
+    return `(${toFormat.slice(0, 3)}) ${toFormat.slice(3)}`;
+  }
+  return `(${toFormat.slice(0, 3)}) ${toFormat.slice(3, 6)}-${toFormat.slice(6)}`;
+}
+
 export const formatUSPhoneNationalDisplay = (phoneNumber: string | null | undefined): string => {
   if (!phoneNumber?.trim()) return "";
 

--- a/src/services/utils/superviseeProfileForm.ts
+++ b/src/services/utils/superviseeProfileForm.ts
@@ -1,0 +1,250 @@
+import type { SuperviseeDetails, SuperviseeUpdatePayload } from "@/services/types/supervisee";
+import { formatUSPhoneForDisplay } from "@/services/utils/phoneNumberUtils";
+
+export type SuperviseeFieldErrors = Partial<
+  Record<keyof SuperviseeEditFormData | "uploadProfilePhoto", string>
+>;
+
+export function validateSuperviseeEditForm(form: SuperviseeEditFormData): SuperviseeFieldErrors {
+  const errors: SuperviseeFieldErrors = {};
+
+  if (!form.fullName.trim()) {
+    errors.fullName = "Full name is required";
+  }
+
+  const phoneDigits = form.contactNumber.replace(/\D/g, "");
+  if (phoneDigits.length < 10) {
+    errors.contactNumber = "Contact number is required";
+  }
+
+  if (!form.city.trim()) {
+    errors.city = "City is required";
+  }
+  if (!form.state.trim()) {
+    errors.state = "State is required";
+  }
+  if (!form.zipcode.trim()) {
+    errors.zipcode = "Zipcode is required";
+  }
+
+  if (!form.occupation) {
+    errors.occupation = "Occupation is required";
+  }
+  if (!form.title.trim()) {
+    errors.title = "Credential or license type is required";
+  }
+  if (!form.stateOfLicensure.length) {
+    errors.stateOfLicensure = "At least one state of licensure is required";
+  }
+
+  if (!form.typeOfSupervisorNeeded) {
+    errors.typeOfSupervisorNeeded = "Type of supervision is required";
+  }
+  if (!form.superviseeOccupation) {
+    errors.superviseeOccupation = "Occupation is required";
+  }
+  if (!form.howSoonLooking) {
+    errors.howSoonLooking = "Please select how soon you need supervision";
+  }
+  if (form.howSoonLooking === "CUSTOM_DATE" && !form.lookingDate) {
+    errors.lookingDate = "Please select a date";
+  }
+  if (!form.preferredFormat) {
+    errors.preferredFormat = "Preferred format is required";
+  }
+  if (!form.availability) {
+    errors.availability = "Availability is required";
+  }
+  if (!form.budgetRangeType) {
+    errors.budgetRangeType = "Budget type is required";
+  }
+  if (form.budgetRangeStart === "") {
+    errors.budgetRangeStart = "Budget start is required";
+  }
+  if (form.budgetRangeEnd === "") {
+    errors.budgetRangeEnd = "Budget end is required";
+  }
+  if (!form.stateTheyAreLookingIn.length) {
+    errors.stateTheyAreLookingIn = "Select at least one state you are looking in";
+  }
+  if (!form.idealSupervisor.trim()) {
+    errors.idealSupervisor = "Description of ideal supervisor is required";
+  } else if (form.idealSupervisor.trim().length < 20) {
+    errors.idealSupervisor = "Description must be at least 20 characters";
+  }
+
+  return errors;
+}
+
+export interface SuperviseeEditFormData {
+  fullName: string;
+  contactNumber: string;
+  city: string;
+  state: string;
+  zipcode: string;
+  occupation: string;
+  specialty: string;
+  title: string;
+  stateOfLicensure: string[];
+  typeOfSupervisorNeeded: string;
+  superviseeOccupation: string;
+  superviseeSpecialty: string;
+  howSoonLooking: string;
+  lookingDate: string;
+  preferredFormat: string;
+  availability: string;
+  idealSupervisor: string;
+  stateTheyAreLookingIn: string[];
+  budgetRangeType: string;
+  budgetRangeStart: string;
+  budgetRangeEnd: string;
+}
+
+export function resolveStateToAbbreviation(
+  raw: string | null | undefined,
+  states: { abbreviation: string; name: string }[],
+): string {
+  if (!raw?.trim()) return "";
+  const trimmed = raw.trim();
+  if (states.some((s) => s.abbreviation === trimmed)) return trimmed;
+  const byName = states.find((s) => s.name.toLowerCase() === trimmed.toLowerCase());
+  return byName?.abbreviation ?? trimmed;
+}
+
+export function coerceStringList(value: string | string[] | null | undefined): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter(Boolean);
+  const trimmed = String(value).trim();
+  return trimmed ? [trimmed] : [];
+}
+
+export function mapSuperviseeDetailsToFormData(
+  details: SuperviseeDetails,
+  states: { abbreviation: string; name: string }[] = [],
+): SuperviseeEditFormData {
+  const profile = details.superviseeProfile;
+  const occupationId = details.occupationId ?? details.occupation?.id ?? "";
+  const specialtyId = details.specialtyId ?? details.specialty?.id ?? "";
+
+  return {
+    fullName: details.fullName ?? "",
+    contactNumber: details.contactNumber
+      ? formatUSPhoneForDisplay(details.contactNumber)
+      : "",
+    city: details.city ?? "",
+    state: resolveStateToAbbreviation(details.state, states),
+    zipcode: details.zipcode ?? "",
+    occupation: occupationId ? String(occupationId) : "",
+    specialty: specialtyId ? String(specialtyId) : "",
+    title: profile?.title ?? "",
+    stateOfLicensure: details.stateOfLicensure ?? [],
+    typeOfSupervisorNeeded: coerceStringList(profile?.typeOfSupervisorNeeded)[0] ?? "",
+    superviseeOccupation: profile?.superviseeOccupation ?? "",
+    superviseeSpecialty: profile?.superviseeSpecialty ?? "",
+    howSoonLooking: profile?.howSoonLooking ?? "",
+    lookingDate: profile?.lookingDate ? profile.lookingDate.slice(0, 10) : "",
+    preferredFormat: profile?.preferredFormat ?? "",
+    availability: profile?.availability ?? "",
+    idealSupervisor: profile?.idealSupervisor ?? "",
+    stateTheyAreLookingIn: profile?.stateTheyAreLookingIn ?? [],
+    budgetRangeType: profile?.budgetRangeType ?? "",
+    budgetRangeStart:
+      profile?.budgetRangeStart != null ? String(profile.budgetRangeStart) : "",
+    budgetRangeEnd: profile?.budgetRangeEnd != null ? String(profile.budgetRangeEnd) : "",
+  };
+}
+
+export function buildSuperviseeUpdateFormData(
+  payload: SuperviseeUpdatePayload,
+): FormData {
+  const fd = new FormData();
+  const {
+    uploadProfilePhoto,
+    stateOfLicensure,
+    typeOfSupervisorNeeded,
+    stateTheyAreLookingIn,
+    budgetRangeStart,
+    budgetRangeEnd,
+    ...rest
+  } = payload;
+
+  for (const [key, value] of Object.entries(rest)) {
+    if (value !== undefined && value !== null && value !== "") {
+      fd.append(key, String(value));
+    }
+  }
+
+  if (budgetRangeStart !== undefined) {
+    fd.append("budgetRangeStart", String(budgetRangeStart));
+  }
+  if (budgetRangeEnd !== undefined) {
+    fd.append("budgetRangeEnd", String(budgetRangeEnd));
+  }
+
+  stateOfLicensure?.forEach((s) => fd.append("stateOfLicensure[]", s));
+  typeOfSupervisorNeeded?.forEach((t) => fd.append("typeOfSupervisorNeeded[]", t));
+  stateTheyAreLookingIn?.forEach((s) => fd.append("stateTheyAreLookingIn[]", s));
+
+  if (uploadProfilePhoto) {
+    fd.append("uploadProfilePhoto", uploadProfilePhoto);
+  }
+
+  return fd;
+}
+
+export function formDataToUpdatePayload(
+  form: SuperviseeEditFormData,
+  uploadProfilePhoto?: File,
+): SuperviseeUpdatePayload {
+  const contactDigits = form.contactNumber.replace(/\D/g, "");
+
+  return {
+    fullName: form.fullName.trim() || undefined,
+    contactNumber: contactDigits || form.contactNumber.trim() || undefined,
+    city: form.city.trim() || undefined,
+    state: form.state.trim() || undefined,
+    zipcode: form.zipcode.trim() || undefined,
+    occupation: form.occupation || undefined,
+    specialty: form.specialty || undefined,
+    title: form.title.trim() || undefined,
+    stateOfLicensure: form.stateOfLicensure.length ? form.stateOfLicensure : undefined,
+    typeOfSupervisorNeeded: form.typeOfSupervisorNeeded
+      ? [form.typeOfSupervisorNeeded]
+      : undefined,
+    superviseeOccupation: form.superviseeOccupation.trim() || undefined,
+    superviseeSpecialty: form.superviseeSpecialty.trim() || undefined,
+    howSoonLooking: form.howSoonLooking || undefined,
+    lookingDate:
+      form.howSoonLooking === "CUSTOM_DATE" ? form.lookingDate || undefined : undefined,
+    preferredFormat: form.preferredFormat || undefined,
+    availability: form.availability || undefined,
+    idealSupervisor: form.idealSupervisor.trim() || undefined,
+    stateTheyAreLookingIn: form.stateTheyAreLookingIn.length
+      ? form.stateTheyAreLookingIn
+      : undefined,
+    budgetRangeType: form.budgetRangeType || undefined,
+    budgetRangeStart: form.budgetRangeStart !== "" ? parseInt(form.budgetRangeStart, 10) : undefined,
+    budgetRangeEnd: form.budgetRangeEnd !== "" ? parseInt(form.budgetRangeEnd, 10) : undefined,
+    uploadProfilePhoto,
+  };
+}
+
+export const HOW_SOON_LABELS: Record<string, string> = {
+  IMMEDIATELY: "Immediately",
+  WITHIN_2_WEEKS: "Within 2 weeks",
+  WITHIN_1_MONTH: "Within 1 month",
+  WITHIN_2_MONTHS: "Within 2 months",
+  WITHIN_6_MONTHS: "Within 6 months",
+  CUSTOM_DATE: "Custom date",
+};
+
+export const FORMAT_LABELS: Record<string, string> = {
+  IN_PERSON: "In-Person",
+  VIRTUAL: "Virtual",
+  HYBRID: "Hybrid",
+};
+
+export const BUDGET_TYPE_LABELS: Record<string, string> = {
+  PER_SESSION: "Per Session",
+  MONTHLY: "Monthly",
+};


### PR DESCRIPTION
Add admin supervisee list, detail view, and edit flow mirroring the Find Supervisor signup experience, with shared form primitives and inline validation.
- Add /admin/supervisees routes, table, pagination, detail page, and sidebar permission guard
- Wire supervisee API hooks, types, and profile form mapping (supervisor-type cascade, occupation/specialty, US phone, state/city)
- Implement Edit Supervisee modal with per-field errors via FormField, ProfilePhotoUpload hover-to-edit, and TextArea styling fix