### PR TITLE
feat(supervisor): add hide/show profile toggle for supervisees and supervisors

### DIFF
--- a/src/components/page/Supervisee/components/HideProfileModal.tsx
+++ b/src/components/page/Supervisee/components/HideProfileModal.tsx
@@ -1,23 +1,29 @@
 import React from "react";
-import { Mail } from "lucide-react";
+import { Eye, EyeOff } from "lucide-react";
 import { Modal } from "@/components/ui/modal";
 import Button from "@/components/ui/button/Button";
 
-interface ResendVerificationModalProps {
+interface HideProfileModalProps {
   isOpen: boolean;
   fullName: string;
+  /** Current visibility state; when true the next action shows (unhides) the profile. */
+  currentlyHidden: boolean;
   onConfirm: () => void;
   onCancel: () => void;
   isLoading: boolean;
 }
 
-const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
+const HideProfileModal: React.FC<HideProfileModalProps> = ({
   isOpen,
   fullName,
+  currentlyHidden,
   onConfirm,
   onCancel,
   isLoading,
 }) => {
+  const willHide = !currentlyHidden;
+  const Icon = willHide ? EyeOff : Eye;
+
   return (
     <Modal
       isOpen={isOpen}
@@ -30,16 +36,24 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
         <div className="px-6 pt-6 pb-4">
           <div className="flex items-start gap-4">
             <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 dark:bg-primary/20">
-              <Mail className="h-6 w-6 text-primary dark:text-primary" aria-hidden />
+              <Icon className="h-6 w-6 text-primary dark:text-primary" aria-hidden />
             </div>
             <div className="flex-1 min-w-0">
               <h3 className="text-lg font-semibold leading-6 text-gray-900 dark:text-white mb-1">
-                Resend Verification Email
+                {willHide ? "Hide Profile" : "Show Profile"}
               </h3>
               <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
-                Resend the email verification link to{" "}
-                <span className="font-medium">{fullName}</span>? They&apos;ll receive a new email
-                prompting them to confirm their address.
+                {willHide ? (
+                  <>
+                    Hide <span className="font-medium">{fullName}</span>&apos;s profile? It will no
+                    longer appear in public listings until you make it visible again.
+                  </>
+                ) : (
+                  <>
+                    Make <span className="font-medium">{fullName}</span>&apos;s profile visible
+                    again? It will reappear in public listings.
+                  </>
+                )}
               </p>
             </div>
           </div>
@@ -49,14 +63,14 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
           <Button
             onClick={onCancel}
             variant="ghost"
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-500 transition-all duration-200"
+            className="px-4 py-2 text-sm font-medium !text-gray-700 dark:!text-gray-300 !bg-white dark:!bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-500 transition-all duration-200"
             disabled={isLoading}
           >
             Cancel
           </Button>
           <Button
             onClick={onConfirm}
-            className="px-4 py-2 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-4 py-2 text-sm font-medium text-white !bg-primary rounded-lg hover:!bg-primary/90 transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
             disabled={isLoading}
           >
             {isLoading ? (
@@ -74,10 +88,12 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   />
                 </svg>
-                Sending…
+                Saving…
               </div>
+            ) : willHide ? (
+              "Hide Profile"
             ) : (
-              "Resend Email"
+              "Show Profile"
             )}
           </Button>
         </div>
@@ -86,4 +102,4 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
   );
 };
 
-export default ResendVerificationModal;
+export default HideProfileModal;

--- a/src/components/page/Supervisee/components/SuperviseeRowActions.tsx
+++ b/src/components/page/Supervisee/components/SuperviseeRowActions.tsx
@@ -1,37 +1,33 @@
 "use client";
 
 import React, { useRef, useState } from "react";
-import { Check, Eye, EyeOff, Mail, MoreVertical, Pencil, X } from "lucide-react";
+import { Eye, EyeOff, Mail, MoreVertical, Pencil } from "lucide-react";
 import { Dropdown } from "../../../ui/dropdown/Dropdown";
 import { DropdownItem } from "../../../ui/dropdown/DropdownItem";
-import { Supervisor } from "@/services/types/supervisor";
+import { Supervisee } from "@/services/types/supervisee";
 
 const iconProps = { size: 16, className: "shrink-0" } as const;
 const itemClass = "flex items-center gap-2 dark:text-gray-300 dark:hover:bg-white/[0.05]";
 
-interface SupervisorRowActionsProps {
-  supervisor: Supervisor;
+interface SuperviseeRowActionsProps {
+  supervisee: Supervisee;
   onView: (id: string) => void;
   onEdit: (id: string, name: string) => void;
-  onApprove: (id: string, name: string) => void;
-  onReject: (id: string, name: string) => void;
   onResendVerification: (id: string, name: string) => void;
   onToggleHideProfile: (id: string, name: string, currentlyHidden: boolean) => void;
 }
 
-const SupervisorRowActions: React.FC<SupervisorRowActionsProps> = ({
-  supervisor,
+const SuperviseeRowActions: React.FC<SuperviseeRowActionsProps> = ({
+  supervisee,
   onView,
   onEdit,
-  onApprove,
-  onReject,
   onResendVerification,
   onToggleHideProfile,
 }) => {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-  const name = supervisor.fullName || supervisor.email;
+  const name = supervisee.fullName || supervisee.email;
   const close = () => setOpen(false);
   const run = (fn: () => void) => () => {
     close();
@@ -61,16 +57,16 @@ const SupervisorRowActions: React.FC<SupervisorRowActionsProps> = ({
         <DropdownItem
           tag="button"
           className={itemClass}
-          onClick={run(() => onView(supervisor.id))}
+          onClick={run(() => onView(supervisee.id))}
         >
           <Eye {...iconProps} /> View details
         </DropdownItem>
 
-        {supervisor.emailVerified === false && (
+        {!supervisee.emailVerified && (
           <DropdownItem
             tag="button"
             className={itemClass}
-            onClick={run(() => onResendVerification(supervisor.id, name))}
+            onClick={run(() => onResendVerification(supervisee.id, name))}
           >
             <Mail {...iconProps} /> Resend verification email
           </DropdownItem>
@@ -79,37 +75,17 @@ const SupervisorRowActions: React.FC<SupervisorRowActionsProps> = ({
         <DropdownItem
           tag="button"
           className={itemClass}
-          onClick={run(() => onEdit(supervisor.id, name))}
+          onClick={run(() => onEdit(supervisee.id, name))}
         >
           <Pencil {...iconProps} /> Edit
         </DropdownItem>
 
-        {supervisor.verificationStatus !== "APPROVED" && (
-          <DropdownItem
-            tag="button"
-            className={itemClass}
-            onClick={run(() => onApprove(supervisor.id, name))}
-          >
-            <Check {...iconProps} /> Approve
-          </DropdownItem>
-        )}
-
-        {supervisor.verificationStatus !== "REJECTED" && (
-          <DropdownItem
-            tag="button"
-            className={itemClass}
-            onClick={run(() => onReject(supervisor.id, name))}
-          >
-            <X {...iconProps} /> Reject
-          </DropdownItem>
-        )}
-
         <DropdownItem
           tag="button"
           className={itemClass}
-          onClick={run(() => onToggleHideProfile(supervisor.id, name, supervisor.hideProfile))}
+          onClick={run(() => onToggleHideProfile(supervisee.id, name, supervisee.hideProfile))}
         >
-          {supervisor.hideProfile ? (
+          {supervisee.hideProfile ? (
             <>
               <Eye {...iconProps} /> Show profile
             </>
@@ -124,4 +100,4 @@ const SupervisorRowActions: React.FC<SupervisorRowActionsProps> = ({
   );
 };
 
-export default SupervisorRowActions;
+export default SuperviseeRowActions;

--- a/src/components/page/Supervisee/components/SuperviseeTable.tsx
+++ b/src/components/page/Supervisee/components/SuperviseeTable.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Eye, Mail, Pencil } from "lucide-react";
 import { formatDate } from "@/services/utils/dateUtils";
 import { formatUsStateCodeForDisplay } from "@/services/utils/formatUsStateLicensure";
 import { formatUSPhoneNationalDisplay } from "@/services/utils/phoneNumberUtils";
@@ -11,23 +10,31 @@ import { Table, TableBody, TableCell, TableRow } from "../../../ui/table";
 import Avatar from "../../../ui/avatar/Avatar";
 import TableHeading from "../../../tables/tableHeader";
 import EmailVerifiedBadge from "../../../ui/badge/EmailVerifiedBadge";
+import VisibilityBadge from "../../../ui/badge/VisibilityBadge";
+import SuperviseeRowActions from "./SuperviseeRowActions";
 import { SuperviseeTableProps } from "@/services/types/SuperviseeTypes";
-
-const ACTION_ICON_PX = 16;
-const actionIconProps = { size: ACTION_ICON_PX, className: "shrink-0" } as const;
 
 const SuperviseeTable: React.FC<SuperviseeTableProps> = ({
   data,
   isLoading,
   tableColumns,
+  sortBy,
+  sortOrder,
+  onSort,
   onViewSupervisee,
   onEditSupervisee,
   onResendVerification,
+  onToggleHideProfile,
 }) => {
   return (
     <div className="overflow-x-auto">
       <Table className="min-w-full">
-        <TableHeading columns={tableColumns} />
+        <TableHeading
+          columns={tableColumns}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
         <TableBody>
           {isLoading ? (
             <TableRow>
@@ -104,40 +111,24 @@ const SuperviseeTable: React.FC<SuperviseeTableProps> = ({
                   <EmailVerifiedBadge verified={supervisee.emailVerified} />
                 </TableCell>
 
+                {/* Visibility in Find a Supervisor app */}
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <VisibilityBadge hidden={supervisee.hideProfile} />
+                </TableCell>
+
                 <TableCell className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                   {formatDate(supervisee.createdAt)}
                 </TableCell>
 
                 <TableCell className="px-4 py-3 whitespace-nowrap text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    <button
-                      onClick={() => onViewSupervisee(supervisee.id)}
-                      title="View details"
-                      className="p-1.5 text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400 rounded transition-colors"
-                    >
-                      <Eye {...actionIconProps} />
-                    </button>
-
-                    {!supervisee.emailVerified && (
-                      <button
-                        onClick={() =>
-                          onResendVerification(supervisee.id, supervisee.fullName || supervisee.email)
-                        }
-                        title="Resend verification email"
-                        className="p-1.5 text-gray-500 hover:text-warning-600 dark:text-gray-400 dark:hover:text-warning-400 rounded transition-colors"
-                      >
-                        <Mail {...actionIconProps} />
-                      </button>
-                    )}
-                    <button
-                      onClick={() =>
-                        onEditSupervisee(supervisee.id, supervisee.fullName || supervisee.email)
-                      }
-                      title="Edit supervisee"
-                      className="p-1.5 text-gray-500 hover:text-brand-600 dark:text-gray-400 dark:hover:text-brand-400 rounded transition-colors"
-                    >
-                      <Pencil {...actionIconProps} />
-                    </button>
+                  <div className="flex items-center justify-end">
+                    <SuperviseeRowActions
+                      supervisee={supervisee}
+                      onView={onViewSupervisee}
+                      onEdit={onEditSupervisee}
+                      onResendVerification={onResendVerification}
+                      onToggleHideProfile={onToggleHideProfile}
+                    />
                   </div>
                 </TableCell>
               </TableRow>

--- a/src/components/page/Supervisee/components/index.ts
+++ b/src/components/page/Supervisee/components/index.ts
@@ -1,5 +1,7 @@
 export { default as SuperviseeHeader } from "./SuperviseeHeader";
 export { default as SuperviseeTable } from "./SuperviseeTable";
+export { default as SuperviseeRowActions } from "./SuperviseeRowActions";
 export { default as SuperviseeTablePagination } from "./SuperviseeTablePagination";
 export { EditSuperviseeModal } from "./EditSuperviseeModal";
 export { default as ResendVerificationModal } from "./ResendVerificationModal";
+export { default as HideProfileModal } from "./HideProfileModal";

--- a/src/components/page/Supervisee/index.tsx
+++ b/src/components/page/Supervisee/index.tsx
@@ -12,6 +12,7 @@ import {
   SuperviseeTablePagination,
   EditSuperviseeModal,
   ResendVerificationModal,
+  HideProfileModal,
 } from "./components";
 
 const Supervisees: React.FC<SuperviseesProps> = ({ className = "" }) => {
@@ -32,6 +33,9 @@ const Supervisees: React.FC<SuperviseesProps> = ({ className = "" }) => {
     refetch,
     tableColumns,
     itemsPerPageOptions,
+    sortBy,
+    sortOrder,
+    handleSort,
     filterChange,
     initPageChange,
     viewSupervisee,
@@ -44,6 +48,12 @@ const Supervisees: React.FC<SuperviseesProps> = ({ className = "" }) => {
     openResendModal,
     closeResendModal,
     confirmResend,
+
+    hideProfileModal,
+    isHidingProfile,
+    openHideProfileModal,
+    closeHideProfileModal,
+    confirmHideProfile,
   } = useSuperviseeLogic();
 
   if (error && !isPending) {
@@ -73,9 +83,13 @@ const Supervisees: React.FC<SuperviseesProps> = ({ className = "" }) => {
           data={data}
           isLoading={isLoading}
           tableColumns={tableColumns}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
           onViewSupervisee={viewSupervisee}
           onEditSupervisee={openEditModal}
           onResendVerification={openResendModal}
+          onToggleHideProfile={openHideProfileModal}
         />
 
         <SuperviseeTablePagination
@@ -101,6 +115,15 @@ const Supervisees: React.FC<SuperviseesProps> = ({ className = "" }) => {
         onConfirm={confirmResend}
         onCancel={closeResendModal}
         isLoading={isResending}
+      />
+
+      <HideProfileModal
+        isOpen={hideProfileModal.isOpen}
+        fullName={hideProfileModal.fullName}
+        currentlyHidden={hideProfileModal.currentlyHidden}
+        onConfirm={confirmHideProfile}
+        onCancel={closeHideProfileModal}
+        isLoading={isHidingProfile}
       />
     </>
   );

--- a/src/components/page/Supervisor/components/EditVerificationNotesModal.tsx
+++ b/src/components/page/Supervisor/components/EditVerificationNotesModal.tsx
@@ -35,8 +35,8 @@ const EditVerificationNotesModal: React.FC<EditVerificationNotesModalProps> = ({
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl overflow-hidden">
         <div className="px-6 pt-6 pb-4">
           <div className="flex items-start gap-4">
-            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-brand-50 dark:bg-brand-500/20">
-              <Pencil className="h-6 w-6 text-brand-600 dark:text-brand-400" aria-hidden />
+            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 dark:bg-primary/20">
+              <Pencil className="h-6 w-6 text-primary dark:text-primary" aria-hidden />
             </div>
             <div className="flex-1 min-w-0">
               <h3 className="text-lg font-semibold leading-6 text-gray-900 dark:text-white mb-1">

--- a/src/components/page/Supervisor/components/HideProfileModal.tsx
+++ b/src/components/page/Supervisor/components/HideProfileModal.tsx
@@ -1,23 +1,29 @@
 import React from "react";
-import { Mail } from "lucide-react";
+import { Eye, EyeOff } from "lucide-react";
 import { Modal } from "@/components/ui/modal";
 import Button from "@/components/ui/button/Button";
 
-interface ResendVerificationModalProps {
+interface HideProfileModalProps {
   isOpen: boolean;
   fullName: string;
+  /** Current visibility state; when true the next action shows (unhides) the profile. */
+  currentlyHidden: boolean;
   onConfirm: () => void;
   onCancel: () => void;
   isLoading: boolean;
 }
 
-const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
+const HideProfileModal: React.FC<HideProfileModalProps> = ({
   isOpen,
   fullName,
+  currentlyHidden,
   onConfirm,
   onCancel,
   isLoading,
 }) => {
+  const willHide = !currentlyHidden;
+  const Icon = willHide ? EyeOff : Eye;
+
   return (
     <Modal
       isOpen={isOpen}
@@ -30,16 +36,24 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
         <div className="px-6 pt-6 pb-4">
           <div className="flex items-start gap-4">
             <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 dark:bg-primary/20">
-              <Mail className="h-6 w-6 text-primary dark:text-primary" aria-hidden />
+              <Icon className="h-6 w-6 text-primary dark:text-primary" aria-hidden />
             </div>
             <div className="flex-1 min-w-0">
               <h3 className="text-lg font-semibold leading-6 text-gray-900 dark:text-white mb-1">
-                Resend Verification Email
+                {willHide ? "Hide Profile" : "Show Profile"}
               </h3>
               <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
-                Resend the email verification link to{" "}
-                <span className="font-medium">{fullName}</span>? They&apos;ll receive a new email
-                prompting them to confirm their address.
+                {willHide ? (
+                  <>
+                    Hide <span className="font-medium">{fullName}</span>&apos;s profile? It will no
+                    longer appear in public listings until you make it visible again.
+                  </>
+                ) : (
+                  <>
+                    Make <span className="font-medium">{fullName}</span>&apos;s profile visible
+                    again? It will reappear in public listings.
+                  </>
+                )}
               </p>
             </div>
           </div>
@@ -49,14 +63,14 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
           <Button
             onClick={onCancel}
             variant="ghost"
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-500 transition-all duration-200"
+            className="px-4 py-2 text-sm font-medium !text-gray-700 dark:!text-gray-300 !bg-white dark:!bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-500 transition-all duration-200"
             disabled={isLoading}
           >
             Cancel
           </Button>
           <Button
             onClick={onConfirm}
-            className="px-4 py-2 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-4 py-2 text-sm font-medium text-white !bg-primary rounded-lg hover:!bg-primary/90 transition-all duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
             disabled={isLoading}
           >
             {isLoading ? (
@@ -74,10 +88,12 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   />
                 </svg>
-                Sending…
+                Saving…
               </div>
+            ) : willHide ? (
+              "Hide Profile"
             ) : (
-              "Resend Email"
+              "Show Profile"
             )}
           </Button>
         </div>
@@ -86,4 +102,4 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
   );
 };
 
-export default ResendVerificationModal;
+export default HideProfileModal;

--- a/src/components/page/Supervisor/components/ResendVerificationModal.tsx
+++ b/src/components/page/Supervisor/components/ResendVerificationModal.tsx
@@ -29,8 +29,8 @@ const ResendVerificationModal: React.FC<ResendVerificationModalProps> = ({
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl overflow-hidden">
         <div className="px-6 pt-6 pb-4">
           <div className="flex items-start gap-4">
-            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-brand-50 dark:bg-brand-500/20">
-              <Mail className="h-6 w-6 text-brand-600 dark:text-brand-400" aria-hidden />
+            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 dark:bg-primary/20">
+              <Mail className="h-6 w-6 text-primary dark:text-primary" aria-hidden />
             </div>
             <div className="flex-1 min-w-0">
               <h3 className="text-lg font-semibold leading-6 text-gray-900 dark:text-white mb-1">

--- a/src/components/page/Supervisor/components/SupervisorTable.tsx
+++ b/src/components/page/Supervisor/components/SupervisorTable.tsx
@@ -6,6 +6,7 @@ import { Table, TableBody, TableCell, TableRow } from "../../../ui/table";
 import Avatar from "../../../ui/avatar/Avatar";
 import TableHeading from "../../../tables/tableHeader";
 import EmailVerifiedBadge from "../../../ui/badge/EmailVerifiedBadge";
+import VisibilityBadge from "../../../ui/badge/VisibilityBadge";
 import SupervisorStatusBadge from "./SupervisorStatusBadge";
 import SupervisorRowActions from "./SupervisorRowActions";
 import { SupervisorTableProps } from "@/services/types/SupervisorTypes";
@@ -18,20 +19,41 @@ function renderOptionalCredential(value: string | null | undefined) {
   );
 }
 
+// Join the secondary role details (occupation, specialty) into a single
+// muted sub-line; renders nothing when none are present.
+function renderRoleSubtext(values: Array<string | null | undefined>) {
+  const parts = values.map((v) => v?.trim()).filter(Boolean);
+  if (!parts.length) return null;
+  return (
+    <p className="text-xs text-gray-500 dark:text-gray-400">
+      {parts.join(" · ")}
+    </p>
+  );
+}
+
 const SupervisorTable: React.FC<SupervisorTableProps> = ({
   data,
   isLoading,
   tableColumns,
+  sortBy,
+  sortOrder,
+  onSort,
   onViewSupervisor,
   onEditSupervisor,
   onApproveSupervisor,
   onRejectSupervisor,
   onResendVerification,
+  onToggleHideProfile,
 }) => {
   return (
     <div className="overflow-x-auto">
       <Table className="min-w-full">
-        <TableHeading columns={tableColumns} />
+        <TableHeading
+          columns={tableColumns}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={onSort}
+        />
         <TableBody>
           {isLoading ? (
             <TableRow>
@@ -75,7 +97,7 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                 key={supervisor.id}
                 className="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-white/[0.02] transition-colors"
               >
-                {/* Name + Avatar */}
+                {/* Name + Avatar (with email and phone stacked beneath) */}
                 <TableCell className="px-4 py-3 whitespace-nowrap">
                   <div className="flex items-center gap-3">
                     <Avatar
@@ -84,8 +106,11 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                       size="small"
                     />
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate max-w-[160px]">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate max-w-[220px]">
                         {supervisor.fullName || "—"}
+                      </p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[220px]">
+                        {supervisor.email}
                       </p>
                       {supervisor.contactNumber && (
                         <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -96,11 +121,6 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                   </div>
                 </TableCell>
 
-                {/* Email */}
-                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                  {supervisor.email}
-                </TableCell>
-
                 {/* State: full name (abbr) */}
                 <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
                   {formatUsStateCodeForDisplay(supervisor.state) || (
@@ -108,25 +128,21 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                   )}
                 </TableCell>
 
-                {/* Supervisor Type */}
-                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
-                  {supervisor.supervisorType || (
-                    <span className="text-gray-400 italic">Not specified</span>
-                  )}
-                </TableCell>
-
-                {/* Occupation */}
-                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
-                  {supervisor.supervisorOccupation || (
-                    <span className="text-gray-400 italic">Not specified</span>
-                  )}
-                </TableCell>
-
-                {/* Specialty */}
-                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
-                  {supervisor.supervisorSpecialty || (
-                    <span className="text-gray-400 italic">Not specified</span>
-                  )}
+                {/* Role: supervisor type + occupation · specialty */}
+                <TableCell className="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {supervisor.supervisorType || (
+                        <span className="font-normal text-gray-400 italic">
+                          Not specified
+                        </span>
+                      )}
+                    </p>
+                    {renderRoleSubtext([
+                      supervisor.supervisorOccupation,
+                      supervisor.supervisorSpecialty,
+                    ])}
+                  </div>
                 </TableCell>
 
                 {/* License Type */}
@@ -158,6 +174,11 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                   <EmailVerifiedBadge verified={supervisor.emailVerified} />
                 </TableCell>
 
+                {/* Visibility in Find a Supervisor app */}
+                <TableCell className="px-4 py-3 whitespace-nowrap">
+                  <VisibilityBadge hidden={supervisor.hideProfile} />
+                </TableCell>
+
                 {/* Submitted date */}
                 <TableCell className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                   {formatDate(supervisor.createdAt)}
@@ -173,6 +194,7 @@ const SupervisorTable: React.FC<SupervisorTableProps> = ({
                       onApprove={onApproveSupervisor}
                       onReject={onRejectSupervisor}
                       onResendVerification={onResendVerification}
+                      onToggleHideProfile={onToggleHideProfile}
                     />
                   </div>
                 </TableCell>

--- a/src/components/page/Supervisor/components/index.ts
+++ b/src/components/page/Supervisor/components/index.ts
@@ -8,3 +8,4 @@ export { default as ApproveSupervisorModal } from "./ApproveSupervisorModal";
 export { default as EditVerificationNotesModal } from "./EditVerificationNotesModal";
 export { default as ResendVerificationModal } from "./ResendVerificationModal";
 export { default as EditSupervisorModal } from "./EditSupervisorModal";
+export { default as HideProfileModal } from "./HideProfileModal";

--- a/src/components/page/Supervisor/index.tsx
+++ b/src/components/page/Supervisor/index.tsx
@@ -14,6 +14,7 @@ import {
   ApproveSupervisorModal,
   EditSupervisorModal,
   ResendVerificationModal,
+  HideProfileModal,
 } from "./components";
 
 const Supervisors: React.FC<SupervisorsProps> = ({ className = "" }) => {
@@ -39,6 +40,9 @@ const Supervisors: React.FC<SupervisorsProps> = ({ className = "" }) => {
     tableColumns,
     statusOptions,
     itemsPerPageOptions,
+    sortBy,
+    sortOrder,
+    handleSort,
     filterChange,
     initPageChange,
     viewSupervisor,
@@ -70,6 +74,12 @@ const Supervisors: React.FC<SupervisorsProps> = ({ className = "" }) => {
     openResendModal,
     closeResendModal,
     confirmResend,
+
+    hideProfileModal,
+    isHidingProfile,
+    openHideProfileModal,
+    closeHideProfileModal,
+    confirmHideProfile,
   } = useSupervisorLogic();
 
   if (error && !isPending) {
@@ -114,11 +124,15 @@ const Supervisors: React.FC<SupervisorsProps> = ({ className = "" }) => {
           data={data}
           isLoading={isLoading}
           tableColumns={tableColumns}
+          sortBy={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
           onViewSupervisor={viewSupervisor}
           onEditSupervisor={openEditModal}
           onApproveSupervisor={openApproveModal}
           onRejectSupervisor={openRejectModal}
           onResendVerification={openResendModal}
+          onToggleHideProfile={openHideProfileModal}
           onRefresh={refetch}
         />
 
@@ -165,6 +179,15 @@ const Supervisors: React.FC<SupervisorsProps> = ({ className = "" }) => {
         onConfirm={confirmResend}
         onCancel={closeResendModal}
         isLoading={isResending}
+      />
+
+      <HideProfileModal
+        isOpen={hideProfileModal.isOpen}
+        fullName={hideProfileModal.fullName}
+        currentlyHidden={hideProfileModal.currentlyHidden}
+        onConfirm={confirmHideProfile}
+        onCancel={closeHideProfileModal}
+        isLoading={isHidingProfile}
       />
     </>
   );

--- a/src/components/tables/tableHeader.tsx
+++ b/src/components/tables/tableHeader.tsx
@@ -1,29 +1,75 @@
 import React, { ReactNode } from "react";
+import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
 import { TableHeader, TableRow, TableCell } from "../ui/table";
 
 export interface TableHeaderColumn {
   key: string;
   label: string | ReactNode;
   className?: string;
+  /**
+   * When set, the column header becomes a sort toggle that calls `onSort`
+   * with this key. The value is sent to the backend as `sortBy`.
+   */
+  sortKey?: string;
 }
 
 interface TableHeadingProps {
   columns: TableHeaderColumn[];
   className?: string;
+  /** Currently active sort key (matches a column's `sortKey`). */
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+  /** Called with the column's `sortKey` when a sortable header is clicked. */
+  onSort?: (sortKey: string) => void;
 }
 
-const TableHeading: React.FC<TableHeadingProps> = ({ columns, className = "" }) => {
+const TableHeading: React.FC<TableHeadingProps> = ({
+  columns,
+  className = "",
+  sortBy,
+  sortOrder,
+  onSort,
+}) => {
   return (
     <TableHeader className={className}>
       <TableRow className="border-b border-gray-200 dark:border-gray-800">
-        {columns.map((column) => (
-          <TableCell
-            key={column.key}
-            className={`py-4 px-6 font-semibold text-gray-900 dark:text-white text-sm ${column.className || ""}`}
-          >
-            {column.label}
-          </TableCell>
-        ))}
+        {columns.map((column) => {
+          const sortable = Boolean(column.sortKey && onSort);
+          const isActive = sortable && sortBy === column.sortKey;
+
+          return (
+            <TableCell
+              key={column.key}
+              className={`py-4 px-6 font-semibold text-gray-900 dark:text-white text-sm ${column.className || ""}`}
+            >
+              {sortable ? (
+                <button
+                  type="button"
+                  onClick={() => onSort!(column.sortKey!)}
+                  title={
+                    isActive
+                      ? `Sorted ${sortOrder === "asc" ? "ascending" : "descending"} — click to toggle`
+                      : "Sort"
+                  }
+                  className="flex items-center gap-1 font-semibold hover:text-brand-500 transition-colors"
+                >
+                  {column.label}
+                  {isActive ? (
+                    sortOrder === "asc" ? (
+                      <ChevronUp className="w-3.5 h-3.5" />
+                    ) : (
+                      <ChevronDown className="w-3.5 h-3.5" />
+                    )
+                  ) : (
+                    <ChevronsUpDown className="w-3.5 h-3.5 text-gray-400" />
+                  )}
+                </button>
+              ) : (
+                column.label
+              )}
+            </TableCell>
+          );
+        })}
       </TableRow>
     </TableHeader>
   );

--- a/src/components/ui/badge/VisibilityBadge.tsx
+++ b/src/components/ui/badge/VisibilityBadge.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Eye, EyeOff } from "lucide-react";
+
+const baseClass =
+  "inline-flex items-center justify-center gap-1 rounded-sm px-2.5 py-0.5 font-medium whitespace-nowrap text-theme-xs";
+
+// Shown -> neutral/positive, Hidden -> amber so admins can spot profiles
+// that are not visible in the Find a Supervisor app at a glance.
+const shownClass =
+  "bg-emerald-50 text-emerald-800 ring-1 ring-inset ring-emerald-200/90 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-700/50";
+const hiddenClass =
+  "bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200/90 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-700/50";
+
+interface VisibilityBadgeProps {
+  /** True when the profile is hidden from the Find a Supervisor app. */
+  hidden: boolean;
+  className?: string;
+}
+
+const VisibilityBadge: React.FC<VisibilityBadgeProps> = ({
+  hidden,
+  className = "",
+}) => {
+  return (
+    <span className={`${baseClass} ${hidden ? hiddenClass : shownClass} ${className}`.trim()}>
+      {hidden ? (
+        <>
+          <EyeOff size={12} className="shrink-0" /> Hidden
+        </>
+      ) : (
+        <>
+          <Eye size={12} className="shrink-0" /> Shown
+        </>
+      )}
+    </span>
+  );
+};
+
+export default VisibilityBadge;

--- a/src/services/api/supervisee.ts
+++ b/src/services/api/supervisee.ts
@@ -6,6 +6,7 @@ import {
   SuperviseeUpdateResponse,
   SuperviseesResponse,
 } from "../types/supervisee";
+import { HideProfileResponse } from "../types/supervisor";
 import { apiGet, apiPatch, apiPost } from "./apiUtils";
 import { buildSuperviseeUpdateFormData } from "../utils/superviseeProfileForm";
 import { showToast } from "../utils/toast";
@@ -18,6 +19,8 @@ export const superviseeApi = {
       if (filters.page) queryParams.append("page", filters.page.toString());
       if (filters.limit) queryParams.append("limit", filters.limit.toString());
       if (filters.keyword) queryParams.append("keyword", filters.keyword);
+      if (filters.sortBy) queryParams.append("sortBy", filters.sortBy);
+      if (filters.sortOrder) queryParams.append("sortOrder", filters.sortOrder);
 
       const endpoint = `/api/supervision/admin/supervisees?${queryParams.toString()}`;
       return apiGet<SuperviseesResponse>(endpoint);
@@ -51,6 +54,17 @@ export const superviseeApi = {
     return apiPatch<SuperviseeUpdateResponse>(
       `/api/supervision/admin/supervisees/${id}`,
       formData,
+    );
+  },
+
+  /**
+   * Hide or show a supervisee's public profile.
+   * `id` is the supervision user id. Note the endpoint has no `/supervisees/` segment.
+   */
+  async setHideProfile(id: string, hideProfile: boolean): Promise<HideProfileResponse> {
+    return apiPatch<HideProfileResponse>(
+      `/api/supervision/admin/${id}/hide-profile`,
+      { hideProfile },
     );
   },
 };

--- a/src/services/api/supervisor.ts
+++ b/src/services/api/supervisor.ts
@@ -6,6 +6,7 @@ import {
   SupervisorResendVerificationResponse,
   SupervisorUpdatePayload,
   SupervisorUpdateResponse,
+  HideProfileResponse,
 } from "../types/supervisor";
 import { buildSupervisorUpdateFormData } from "../utils/supervisorProfileForm";
 import { apiGet, apiPatch, apiPost } from "./apiUtils";
@@ -21,6 +22,8 @@ export const supervisorApi = {
       if (filters.keyword) queryParams.append("keyword", filters.keyword);
       // Only send verificationStatus when a specific one is selected; omitting it returns all statuses
       if (filters.verificationStatus) queryParams.append("verificationStatus", filters.verificationStatus);
+      if (filters.sortBy) queryParams.append("sortBy", filters.sortBy);
+      if (filters.sortOrder) queryParams.append("sortOrder", filters.sortOrder);
 
       const endpoint = `/api/supervision/admin/supervisors?${queryParams.toString()}`;
       return apiGet<SupervisorsResponse>(endpoint);
@@ -73,6 +76,17 @@ export const supervisorApi = {
     return apiPatch<SupervisorUpdateResponse>(
       `/api/supervision/admin/supervisors/${id}`,
       formData,
+    );
+  },
+
+  /**
+   * Hide or show a supervisor's public profile.
+   * `id` is the supervision user id. Note the endpoint has no `/supervisors/` segment.
+   */
+  async setHideProfile(id: string, hideProfile: boolean): Promise<HideProfileResponse> {
+    return apiPatch<HideProfileResponse>(
+      `/api/supervision/admin/${id}/hide-profile`,
+      { hideProfile },
     );
   },
 };

--- a/src/services/hooks/useSuperviseeLogic.ts
+++ b/src/services/hooks/useSuperviseeLogic.ts
@@ -1,7 +1,11 @@
 import { useState, useMemo, useTransition, useEffect, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useSupervisees, useResendSuperviseeVerification } from "@/services/hooks/useSupervisees";
-import { SuperviseeFilters } from "@/services/types/supervisee";
+import {
+  useSupervisees,
+  useResendSuperviseeVerification,
+  useHideSuperviseeProfile,
+} from "@/services/hooks/useSupervisees";
+import { SuperviseeFilters, SuperviseeSortBy } from "@/services/types/supervisee";
 
 export const useSuperviseeLogic = () => {
   const router = useRouter();
@@ -44,6 +48,8 @@ export const useSuperviseeLogic = () => {
               page: Math.max(1, parsed.page || 1),
               limit: parsed.limit || 10,
               keyword: parsed.keyword || "",
+              sortBy: parsed.sortBy || undefined,
+              sortOrder: parsed.sortOrder || undefined,
             };
           } catch {
             // fall through
@@ -77,7 +83,15 @@ export const useSuperviseeLogic = () => {
     fullName: string;
   }>({ isOpen: false, superviseeId: "", fullName: "" });
 
+  const [hideProfileModal, setHideProfileModal] = useState<{
+    isOpen: boolean;
+    superviseeId: string;
+    fullName: string;
+    currentlyHidden: boolean;
+  }>({ isOpen: false, superviseeId: "", fullName: "", currentlyHidden: false });
+
   const { mutate: resendMutate, isPending: isResending } = useResendSuperviseeVerification();
+  const { mutate: hideProfileMutate, isPending: isHidingProfile } = useHideSuperviseeProfile();
 
   useEffect(() => {
     setIsInitialized(true);
@@ -126,6 +140,8 @@ export const useSuperviseeLogic = () => {
           page: filters.page,
           limit: filters.limit,
           keyword: filters.keyword,
+          sortBy: filters.sortBy,
+          sortOrder: filters.sortOrder,
         }),
       );
     }
@@ -135,17 +151,30 @@ export const useSuperviseeLogic = () => {
 
   const tableColumns = useMemo(
     () => [
-      { key: "name", label: "Name" },
+      { key: "name", label: "Name", sortKey: "fullName" },
       { key: "email", label: "Email" },
-      { key: "state", label: "State" },
+      { key: "state", label: "State", sortKey: "state" },
       { key: "format", label: "Preferred Format" },
       { key: "howSoon", label: "How Soon" },
       { key: "emailVerified", label: "Email" },
-      { key: "createdAt", label: "Registered" },
+      { key: "visibility", label: "Visibility", sortKey: "hideProfile" },
+      { key: "createdAt", label: "Registered", sortKey: "createdAt" },
       { key: "actions", label: "", className: "text-right" },
     ],
     [],
   );
+
+  const handleSort = useCallback((sortKey: string) => {
+    startTransition(() => {
+      setFilters((prev) => ({
+        ...prev,
+        sortBy: sortKey as SuperviseeSortBy,
+        // Toggle direction when re-clicking the active column; default to asc.
+        sortOrder: prev.sortBy === sortKey && prev.sortOrder === "asc" ? "desc" : "asc",
+        page: 1,
+      }));
+    });
+  }, []);
 
   const itemsPerPageOptions = useMemo(
     () => [
@@ -207,6 +236,30 @@ export const useSuperviseeLogic = () => {
     resendMutate(resendModal.superviseeId, { onSettled: closeResendModal });
   }, [resendModal.superviseeId, resendMutate, closeResendModal]);
 
+  const openHideProfileModal = useCallback(
+    (superviseeId: string, fullName: string, currentlyHidden: boolean) => {
+      setHideProfileModal({ isOpen: true, superviseeId, fullName, currentlyHidden });
+    },
+    [],
+  );
+
+  const closeHideProfileModal = useCallback(() => {
+    setHideProfileModal({ isOpen: false, superviseeId: "", fullName: "", currentlyHidden: false });
+  }, []);
+
+  const confirmHideProfile = useCallback(() => {
+    if (!hideProfileModal.superviseeId) return;
+    hideProfileMutate(
+      { id: hideProfileModal.superviseeId, hideProfile: !hideProfileModal.currentlyHidden },
+      { onSettled: closeHideProfileModal },
+    );
+  }, [
+    hideProfileModal.superviseeId,
+    hideProfileModal.currentlyHidden,
+    hideProfileMutate,
+    closeHideProfileModal,
+  ]);
+
   const clearAllFilters = useCallback(() => {
     setFilters({ page: 1, limit: 10, keyword: "" });
     setSearchInput("");
@@ -249,6 +302,9 @@ export const useSuperviseeLogic = () => {
     refetch,
     tableColumns,
     itemsPerPageOptions,
+    sortBy: filters.sortBy,
+    sortOrder: filters.sortOrder,
+    handleSort,
     filterChange,
     initPageChange,
     viewSupervisee,
@@ -263,5 +319,11 @@ export const useSuperviseeLogic = () => {
     openResendModal,
     closeResendModal,
     confirmResend,
+
+    hideProfileModal,
+    isHidingProfile,
+    openHideProfileModal,
+    closeHideProfileModal,
+    confirmHideProfile,
   };
 };

--- a/src/services/hooks/useSupervisees.ts
+++ b/src/services/hooks/useSupervisees.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, useQueries } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, useQueries, keepPreviousData } from "@tanstack/react-query";
 import { superviseeApi } from "../api/supervisee";
 import {
   fetchSupervisionOptions,
@@ -32,6 +32,9 @@ export const useSupervisees = (filters: SuperviseeFilters = {}) => {
   return useQuery({
     queryKey: superviseeQueryKeys.list(filters),
     queryFn: () => superviseeApi.getSupervisees(filters),
+    // Keep the previous rows on screen while a new page/sort/filter loads,
+    // so the table doesn't flash the full-body spinner on every change.
+    placeholderData: keepPreviousData,
     staleTime: 1000 * 60 * 5,
     retry: (failureCount, error: Error) => {
       if (error.message.includes("HTTP 401")) return false;
@@ -103,6 +106,33 @@ export const useResendSuperviseeVerification = () => {
       showToast.error(
         "Resend Failed",
         error.message || "Failed to resend the verification email. Please try again.",
+      );
+    },
+  });
+};
+
+export const useHideSuperviseeProfile = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, hideProfile }: { id: string; hideProfile: boolean }) =>
+      superviseeApi.setHideProfile(id, hideProfile),
+    onSuccess: async (response, { id }) => {
+      const hidden = response.data?.hideProfile;
+      showToast.success(
+        hidden ? "Profile Hidden" : "Profile Visible",
+        response.message ||
+          (hidden
+            ? "The supervisee's profile is now hidden."
+            : "The supervisee's profile is now visible."),
+      );
+      await queryClient.invalidateQueries({ queryKey: superviseeQueryKeys.lists() });
+      await queryClient.invalidateQueries({ queryKey: superviseeQueryKeys.detail(id) });
+    },
+    onError: (error: Error) => {
+      showToast.error(
+        "Update Failed",
+        error.message || "Failed to update profile visibility. Please try again.",
       );
     },
   });

--- a/src/services/hooks/useSupervisorLogic.ts
+++ b/src/services/hooks/useSupervisorLogic.ts
@@ -5,8 +5,9 @@ import {
   useApproveSupervisor,
   useRejectSupervisor,
   useResendSupervisorVerification,
+  useHideSupervisorProfile,
 } from "@/services/hooks/useSupervisors";
-import { SupervisorFilters, VerificationStatus } from "@/services/types/supervisor";
+import { SupervisorFilters, SupervisorSortBy, VerificationStatus } from "@/services/types/supervisor";
 
 export const useSupervisorLogic = () => {
   const router = useRouter();
@@ -57,6 +58,8 @@ export const useSupervisorLogic = () => {
               limit: parsed.limit || 10,
               keyword: parsed.keyword || "",
               verificationStatus: parsed.verificationStatus || undefined,
+              sortBy: parsed.sortBy || undefined,
+              sortOrder: parsed.sortOrder || undefined,
             };
           } catch {
             // fall through to defaults
@@ -102,12 +105,19 @@ export const useSupervisorLogic = () => {
     supervisorId: "",
     fullName: "",
   });
+  const [hideProfileModal, setHideProfileModal] = useState<{
+    isOpen: boolean;
+    supervisorId: string;
+    fullName: string;
+    currentlyHidden: boolean;
+  }>({ isOpen: false, supervisorId: "", fullName: "", currentlyHidden: false });
   const [rejectNotes, setRejectNotes] = useState("");
   const [approveNotes, setApproveNotes] = useState("");
 
   const { mutate: approveMutate, isPending: isApproving } = useApproveSupervisor();
   const { mutate: rejectMutate, isPending: isRejecting } = useRejectSupervisor();
   const { mutate: resendMutate, isPending: isResending } = useResendSupervisorVerification();
+  const { mutate: hideProfileMutate, isPending: isHidingProfile } = useHideSupervisorProfile();
 
   useEffect(() => {
     setIsInitialized(true);
@@ -160,6 +170,8 @@ export const useSupervisorLogic = () => {
           limit: filters.limit,
           keyword: filters.keyword,
           verificationStatus: filters.verificationStatus,
+          sortBy: filters.sortBy,
+          sortOrder: filters.sortOrder,
         })
       );
     }
@@ -169,22 +181,32 @@ export const useSupervisorLogic = () => {
 
   const tableColumns = useMemo(
     () => [
-      { key: "name", label: "Name" },
-      { key: "email", label: "Email" },
-      { key: "state", label: "State" },
-      { key: "supervisorType", label: "Supervisor Type" },
-      { key: "occupation", label: "Occupation" },
-      { key: "specialty", label: "Specialty" },
+      { key: "name", label: "Name", sortKey: "fullName" },
+      { key: "state", label: "State", sortKey: "state" },
+      { key: "role", label: "Role" },
       { key: "licenseType", label: "License Type" },
       { key: "degreeType", label: "Degree Type" },
-      { key: "yearsOfExperience", label: "Experience" },
-      { key: "verificationStatus", label: "Status" },
+      { key: "yearsOfExperience", label: "Experience", sortKey: "yearsOfExperience" },
+      { key: "verificationStatus", label: "Status", sortKey: "verificationStatus" },
       { key: "emailVerified", label: "Email Verified" },
-      { key: "createdAt", label: "Submitted" },
+      { key: "visibility", label: "Visibility", sortKey: "hideProfile" },
+      { key: "createdAt", label: "Submitted", sortKey: "createdAt" },
       { key: "actions", label: "", className: "text-right" },
     ],
     []
   );
+
+  const handleSort = useCallback((sortKey: string) => {
+    startTransition(() => {
+      setFilters((prev) => ({
+        ...prev,
+        sortBy: sortKey as SupervisorSortBy,
+        // Toggle direction when re-clicking the active column; default to asc.
+        sortOrder: prev.sortBy === sortKey && prev.sortOrder === "asc" ? "desc" : "asc",
+        page: 1,
+      }));
+    });
+  }, []);
 
   const statusOptions = useMemo(
     () => [
@@ -284,6 +306,30 @@ export const useSupervisorLogic = () => {
     resendMutate(resendModal.supervisorId, { onSettled: closeResendModal });
   }, [resendModal.supervisorId, resendMutate, closeResendModal]);
 
+  const openHideProfileModal = useCallback(
+    (supervisorId: string, fullName: string, currentlyHidden: boolean) => {
+      setHideProfileModal({ isOpen: true, supervisorId, fullName, currentlyHidden });
+    },
+    []
+  );
+
+  const closeHideProfileModal = useCallback(() => {
+    setHideProfileModal({ isOpen: false, supervisorId: "", fullName: "", currentlyHidden: false });
+  }, []);
+
+  const confirmHideProfile = useCallback(() => {
+    if (!hideProfileModal.supervisorId) return;
+    hideProfileMutate(
+      { id: hideProfileModal.supervisorId, hideProfile: !hideProfileModal.currentlyHidden },
+      { onSettled: closeHideProfileModal }
+    );
+  }, [
+    hideProfileModal.supervisorId,
+    hideProfileModal.currentlyHidden,
+    hideProfileMutate,
+    closeHideProfileModal,
+  ]);
+
   const confirmReject = useCallback(() => {
     if (!rejectModal.supervisorId || !rejectNotes.trim()) return;
     rejectMutate(
@@ -352,6 +398,10 @@ export const useSupervisorLogic = () => {
     statusOptions,
     itemsPerPageOptions,
 
+    sortBy: filters.sortBy,
+    sortOrder: filters.sortOrder,
+    handleSort,
+
     filterChange,
     initPageChange,
     viewSupervisor,
@@ -383,5 +433,11 @@ export const useSupervisorLogic = () => {
     openResendModal,
     closeResendModal,
     confirmResend,
+
+    hideProfileModal,
+    isHidingProfile,
+    openHideProfileModal,
+    closeHideProfileModal,
+    confirmHideProfile,
   };
 };

--- a/src/services/hooks/useSupervisors.ts
+++ b/src/services/hooks/useSupervisors.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient, useQueries, type QueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, useQueries, keepPreviousData, type QueryClient } from "@tanstack/react-query";
 import { supervisorApi } from "../api/supervisor";
 import {
   SUPERVISION_PROFILE_OPTION_PARAMS,
@@ -57,6 +57,9 @@ export const useSupervisors = (filters: SupervisorFilters = {}) => {
   return useQuery({
     queryKey: supervisorQueryKeys.list(filters),
     queryFn: () => supervisorApi.getSupervisors(filters),
+    // Keep the previous rows on screen while a new page/sort/filter loads,
+    // so the table doesn't flash the full-body spinner on every change.
+    placeholderData: keepPreviousData,
     staleTime: 1000 * 60 * 5,
     retry: (failureCount, error: Error) => {
       if (error.message.includes("HTTP 401")) return false;
@@ -191,6 +194,33 @@ export const useResendSupervisorVerification = () => {
       showToast.error(
         "Resend Failed",
         error.message || "Failed to resend the verification email. Please try again.",
+      );
+    },
+  });
+};
+
+export const useHideSupervisorProfile = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, hideProfile }: { id: string; hideProfile: boolean }) =>
+      supervisorApi.setHideProfile(id, hideProfile),
+    onSuccess: async (response, { id }) => {
+      const hidden = response.data?.hideProfile;
+      showToast.success(
+        hidden ? "Profile Hidden" : "Profile Visible",
+        response.message ||
+          (hidden
+            ? "The supervisor's profile is now hidden."
+            : "The supervisor's profile is now visible."),
+      );
+      await queryClient.invalidateQueries({ queryKey: supervisorQueryKeys.lists() });
+      await queryClient.invalidateQueries({ queryKey: supervisorQueryKeys.detail(id) });
+    },
+    onError: (error: Error) => {
+      showToast.error(
+        "Update Failed",
+        error.message || "Failed to update profile visibility. Please try again.",
       );
     },
   });

--- a/src/services/types/SuperviseeTypes.ts
+++ b/src/services/types/SuperviseeTypes.ts
@@ -14,10 +14,14 @@ export interface SuperviseeHeaderProps {
 export interface SuperviseeTableProps {
   data: SuperviseesResponse | undefined;
   isLoading: boolean;
-  tableColumns: Array<{ key: string; label: string; className?: string }>;
+  tableColumns: Array<{ key: string; label: string; className?: string; sortKey?: string }>;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+  onSort?: (sortKey: string) => void;
   onViewSupervisee: (superviseeId: string) => void;
   onEditSupervisee: (superviseeId: string, fullName: string) => void;
   onResendVerification: (superviseeId: string, fullName: string) => void;
+  onToggleHideProfile: (superviseeId: string, fullName: string, currentlyHidden: boolean) => void;
 }
 
 export interface SuperviseeTablePaginationProps {

--- a/src/services/types/SupervisorTypes.ts
+++ b/src/services/types/SupervisorTypes.ts
@@ -29,12 +29,16 @@ export interface SupervisorFiltersProps {
 export interface SupervisorTableProps {
   data: SupervisorsResponse | undefined;
   isLoading: boolean;
-  tableColumns: Array<{ key: string; label: string; className?: string }>;
+  tableColumns: Array<{ key: string; label: string; className?: string; sortKey?: string }>;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+  onSort?: (sortKey: string) => void;
   onViewSupervisor: (supervisorId: string) => void;
   onEditSupervisor: (supervisorId: string, fullName: string) => void;
   onApproveSupervisor: (supervisorId: string, fullName: string) => void;
   onRejectSupervisor: (supervisorId: string, fullName: string) => void;
   onResendVerification: (supervisorId: string, fullName: string) => void;
+  onToggleHideProfile: (supervisorId: string, fullName: string, currentlyHidden: boolean) => void;
   onRefresh?: () => void;
 }
 

--- a/src/services/types/supervisee.ts
+++ b/src/services/types/supervisee.ts
@@ -30,13 +30,19 @@ export interface Supervisee {
   budgetRangeEnd: number | null;
   superviseeOccupation: string | null;
   superviseeSpecialty: string | null;
+  /** Whether the supervisee's profile is hidden from public listings; drives the Hide/Show action. */
+  hideProfile: boolean;
   createdAt: string;
 }
+
+export type SuperviseeSortBy = "fullName" | "state" | "hideProfile" | "createdAt";
 
 export interface SuperviseeFilters {
   page?: number;
   limit?: number;
   keyword?: string;
+  sortBy?: SuperviseeSortBy;
+  sortOrder?: "asc" | "desc";
 }
 
 export interface SuperviseeResendVerificationResponse {

--- a/src/services/types/supervisor.ts
+++ b/src/services/types/supervisor.ts
@@ -32,13 +32,39 @@ export interface Supervisor {
   /** Email confirmation status; used to gate the "Resend verification email" action. */
   emailVerified: boolean;
   emailVerifiedAt: string | null;
+  /** Whether the supervisor's profile is hidden from public listings; drives the Hide/Show action. */
+  hideProfile: boolean;
 }
+
+/** Response shape from PATCH /api/supervision/admin/:id/hide-profile */
+export interface HideProfileResponse {
+  success: boolean;
+  message: string;
+  data: {
+    id: string;
+    email: string;
+    fullName: string;
+    role: "SUPERVISOR" | "SUPERVISEE";
+    hideProfile: boolean;
+    profileVisibility: "HIDDEN" | "VISIBLE";
+  };
+}
+
+export type SupervisorSortBy =
+  | "fullName"
+  | "state"
+  | "yearsOfExperience"
+  | "verificationStatus"
+  | "hideProfile"
+  | "createdAt";
 
 export interface SupervisorFilters {
   page?: number;
   limit?: number;
   keyword?: string;
   verificationStatus?: VerificationStatus | "";
+  sortBy?: SupervisorSortBy;
+  sortOrder?: "asc" | "desc";
 }
 
 export interface SupervisorsMetaData {


### PR DESCRIPTION
- Add HideProfileModal confirmation dialog (Supervisee + Supervisor) with context-aware Hide/Show copy and a loading state during the API call
- Wire row actions, tables, and page containers to open the modal and trigger the visibility mutation
- Add API endpoints, hooks (useSupervisees/useSupervisors + logic hooks), and types for the hide-profile request and the isHidden field